### PR TITLE
[FIX] checkout_values not autocomplete the fields partner

### DIFF
--- a/website_event_register_free_with_sale/controllers/website_sale.py
+++ b/website_event_register_free_with_sale/controllers/website_sale.py
@@ -51,7 +51,8 @@ class WebsiteSale(website_sale):
         order = request.website.sale_get_order(force_create=0)
         has_paid_tickets = bool(order.order_line)
         if request.session.get('free_tickets') and not has_paid_tickets:
-            values = self.checkout_values(data={'shipping_id': -1})
+            values = self.checkout_values()
+            values['shipping_id'] = -1
             return request.website.render("website_sale.checkout", values)
         else:
             return super(WebsiteSale, self).checkout(**post)


### PR DESCRIPTION
In website_sale in checkout_values checked "data" is empty
https://github.com/odoo/odoo/blob/8.0/addons/website_sale/controllers/main.py#L382
in this case complete partner data https://github.com/odoo/odoo/blob/8.0/addons/website_sale/controllers/main.py#L392
But in the other case partner is empty and not completed in the form.
