### PR TITLE
website sale customer interface

### DIFF
--- a/website_sale_customer/README.rst
+++ b/website_sale_customer/README.rst
@@ -1,12 +1,18 @@
 Customer views for ecommerce
 ============================
 
-TODO
+Adds proper customer views to your shop.
+
+It starts as a port of the improvements done on odoo 9 but it gives you more.
 
 Views
 -----
 
-TODO
+The customer has 2 new items in his/her personal menu: `my account` and `my orders`.
+
+The 1st one allows the customer to edit his/her data with a form that validates the inputs and that ease overrides of validation and other stuff.
+
+The second view allows the customer to view his/her orders without having to deal w/ odoo backend.
 
 
 Credits

--- a/website_sale_customer/README.rst
+++ b/website_sale_customer/README.rst
@@ -14,6 +14,11 @@ The 1st one allows the customer to edit his/her data with a form that validates 
 
 The second view allows the customer to view his/her orders without having to deal w/ odoo backend.
 
+Registration
+------------
+
+This module also add validation to user registration/login and fixes translations for it.
+
 
 Credits
 =======

--- a/website_sale_customer/README.rst
+++ b/website_sale_customer/README.rst
@@ -14,10 +14,17 @@ The 1st one allows the customer to edit his/her data with a form that validates 
 
 The second view allows the customer to view his/her orders without having to deal w/ odoo backend.
 
+
 Registration
 ------------
 
 This module also add validation to user registration/login and fixes translations for it.
+
+
+Notification
+------------
+
+A default email will be sent to the customer whenever he/her gets registered.
 
 
 Credits

--- a/website_sale_customer/README.rst
+++ b/website_sale_customer/README.rst
@@ -1,0 +1,31 @@
+Customer views for ecommerce
+============================
+
+TODO
+
+Views
+-----
+
+TODO
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Simone Orsi <simone.orsi@abstract.it>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+    :alt: Odoo Community Association
+    :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/website_sale_customer/__init__.py
+++ b/website_sale_customer/__init__.py
@@ -18,4 +18,5 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import controllers
+from . import controllers  # noqa
+from . import models  # noqa

--- a/website_sale_customer/__init__.py
+++ b/website_sale_customer/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import controllers

--- a/website_sale_customer/__openerp__.py
+++ b/website_sale_customer/__openerp__.py
@@ -30,6 +30,7 @@
         'website_sale',
     ],
     "data": [
+        'data/website.xml',
         'view/templates_account.xml',
         'view/templates_orders.xml',
     ],

--- a/website_sale_customer/__openerp__.py
+++ b/website_sale_customer/__openerp__.py
@@ -28,9 +28,12 @@
     "depends": [
         'web',
         'website_sale',
+        'base_action_rule',
     ],
     "data": [
         'data/website.xml',
+        'data/emails.xml',
+        'data/action_rules.xml',
         'view/templates_account.xml',
         'view/templates_orders.xml',
     ],

--- a/website_sale_customer/__openerp__.py
+++ b/website_sale_customer/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Website Sale Customer",
+    "version": "1.0",
+    "author": "Abstract.it",
+    "license": "AGPL-3",
+    "category": "Website",
+    "summary": "Customer views for ecommerce",
+    "depends": [
+        'web',
+        'website_sale',
+    ],
+    "data": [
+        'view/templates_account.xml',
+        'view/templates_orders.xml',
+    ],
+    "demo": [
+    ],
+    "test": [
+    ],
+    "auto_install": False,
+    "installable": True,
+    "application": False,
+    "external_dependencies": {
+        'python': [],
+    },
+}

--- a/website_sale_customer/controllers/__init__.py
+++ b/website_sale_customer/controllers/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import account
+from . import orders

--- a/website_sale_customer/controllers/account.py
+++ b/website_sale_customer/controllers/account.py
@@ -43,6 +43,7 @@ class ShopUserAccountController(http.Controller):
             if values["error"]:
                 return request.website.render(self.my_account_template, values)
             self.save_user_form(values['user_info'])
+            values['saved'] = True
         return request.website.render(self.my_account_template, values)
 
     def user_info_values(self, data=None):
@@ -260,6 +261,11 @@ class ShopUserAccountController(http.Controller):
         # save partner informations
         partner_model.write(cr, SUPERUSER_ID, [partner_id], billing_info,
                             context=context)
+
+        if billing_info.get('email'):
+            # we must update login value to keep it synced
+            user_values = {'login': billing_info['email']}
+            user_model.write(cr, SUPERUSER_ID, uid, user_values)
 
         # create a new shipping partner
         if user_info.get('shipping_id') == -1:

--- a/website_sale_customer/controllers/account.py
+++ b/website_sale_customer/controllers/account.py
@@ -11,7 +11,7 @@ from ..utils import validate_phonenumber
 
 
 FIELDS_LABELS = {
-    'name': _(u'Name'),
+    'name': _(u'Fullname'),
     'phone': _(u'Phone'),
     'email': _(u'Email'),
     'street2': _(u'Street'),
@@ -22,7 +22,7 @@ FIELDS_LABELS = {
     'state_id': _(u'State / Province'),
     'vat': _(u'VAT Number'),
     # shipping
-    'shipping_name': _(u'Name (Shipping)'),
+    'shipping_name': _(u'Fullname (Shipping)'),
     'shipping_phone': _(u'Phone'),
     'shipping_email': _(u'Email'),
     'shipping_street2': _(u'Street'),

--- a/website_sale_customer/controllers/account.py
+++ b/website_sale_customer/controllers/account.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+
+from openerp import SUPERUSER_ID
+from openerp import http
+from openerp.http import request
+
+
+class ShopUserAccountController(http.Controller):
+    """ This is mainly a refactoring of `website_sale` checkout controller.
+    """
+    my_account_template = "website_sale_customer.my_account"
+    mandatory_billing_fields = [
+        "name", "phone", "email",
+        "street2", "city", "country_id"
+    ]
+    optional_billing_fields = [
+        "street", "state_id", "vat",
+        "vat_subjected", "zip"
+    ]
+    mandatory_shipping_fields = [
+        "name", "phone", "street",
+        "city", "country_id"
+    ]
+    optional_shipping_fields = ["state_id", "zip"]
+    mandatory_fields = {}.fromkeys(
+        mandatory_billing_fields +
+        ['billing_%s' % x for x in mandatory_shipping_fields],
+        True
+    )
+    # use this to inject your form fields helpers
+    form_fields_helpers = {}
+
+    @http.route(['/shop/my-account'], type='http', auth="user", website=True)
+    def my_account(self, **post):
+        values = self.user_info_values(post)
+        if request.httprequest.method == 'POST':
+            values["error"], values['error_messages'] = \
+                self.validate_user_form(values["user_info"])
+            if values["error"]:
+                return request.website.render(self.my_account_template, values)
+            self.save_user_form(values['user_info'])
+        return request.website.render(self.my_account_template, values)
+
+    def user_info_values(self, data=None):
+        cr, uid, context, registry = \
+            request.cr, request.uid, request.context, request.registry
+        partner_model = registry.get('res.partner')
+        user_model = registry.get('res.users')
+        country_model = registry.get('res.country')
+        state_model = registry.get('res.country.state')
+
+        country_ids = country_model.search(cr, SUPERUSER_ID, [],
+                                           context=context)
+        countries = country_model.browse(cr, SUPERUSER_ID, country_ids,
+                                         context)
+        states_ids = state_model.search(cr, SUPERUSER_ID, [],
+                                        context=context)
+        states = state_model.browse(cr, SUPERUSER_ID, states_ids, context)
+        partner = user_model.browse(cr, SUPERUSER_ID, uid, context).partner_id
+
+        shipping_id = None
+        shipping_ids = []
+        user_info = {}
+        if not data:
+            if request.uid != request.website.user_id.id:
+                user_info.update(self.user_info_parse("billing", partner))
+                shipping_ids = partner_model.search(
+                    cr, SUPERUSER_ID,
+                    [("parent_id", "=", partner.id),
+                     ('type', "=", 'delivery')],
+                    context=context
+                )
+        else:
+            user_info = self.user_info_parse('billing', data)
+            try:
+                shipping_id = int(data["shipping_id"])
+            except ValueError:
+                pass
+            if shipping_id == -1:
+                user_info.update(self.user_info_parse('shipping', data))
+
+        shipping_ids = list(set(shipping_ids) - set([partner.id]))
+
+        if shipping_id == partner.id:
+            shipping_id = 0
+        elif shipping_id > 0 and shipping_id not in shipping_ids:
+            shipping_ids.append(shipping_id)
+        elif shipping_id is None and shipping_ids:
+            shipping_id = shipping_ids[0]
+
+        ctx = dict(context, show_address=1)
+        shippings = []
+        if shipping_ids:
+            shippings = shipping_ids and partner_model.browse(
+                cr, SUPERUSER_ID, list(shipping_ids), ctx) or []
+        if shipping_id > 0:
+            shipping = partner_model.browse(cr, SUPERUSER_ID, shipping_id, ctx)
+            user_info.update(self.user_info_parse("shipping", shipping))
+
+        user_info['shipping_id'] = shipping_id
+
+        # Default_model.search by user country
+        if not user_info.get('country_id'):
+            country_code = request.session['geoip'].get('country_code')
+            if country_code:
+                country_ids = country_model.search(
+                    cr, uid, [('code', '=', country_code)],
+                    context=context)
+                if country_ids:
+                    user_info['country_id'] = country_ids[0]
+
+        values = {
+            'countries': countries,
+            'states': states,
+            'user_info': user_info,
+            'shipping_id': partner.id != shipping_id and shipping_id or 0,
+            'shippings': shippings,
+            'error': {},
+            'form_fields_helpers': self.form_fields_helpers,
+            'mandatory_fields': self.mandatory_fields,
+            'has_check_vat': hasattr(registry['res.partner'], 'check_vat')
+        }
+        return self.prepare_values(values)
+
+    def prepare_values(self, values):
+        """ override this to inject defaults or do other stuff
+        """
+        return values
+
+    def user_info_parse(self, address_type, data, remove_prefix=False):
+        """ data is a dict OR a partner_model.browse record
+        """
+        # set mandatory and optional fields
+        assert address_type in ('billing', 'shipping')
+        if address_type == 'billing':
+            all_fields = self.mandatory_billing_fields + \
+                self.optional_billing_fields
+            prefix = ''
+        else:
+            all_fields = self.mandatory_shipping_fields + \
+                self.optional_shipping_fields
+            prefix = 'shipping_'
+
+        # set data
+        if isinstance(data, dict):
+            query = dict(
+                (prefix + field_name, data[prefix + field_name])
+                for field_name in all_fields
+                if data.get(prefix + field_name)
+            )
+        else:
+            query = dict(
+                (prefix + field_name, getattr(data, field_name))
+                for field_name in all_fields
+                if getattr(data, field_name)
+            )
+            if address_type == 'billing' and data.parent_id:
+                query[prefix + 'street'] = data.parent_id.name
+
+        if query.get(prefix + 'state_id'):
+            query[prefix + 'state_id'] = int(query[prefix + 'state_id'])
+        if query.get(prefix + 'country_id'):
+            query[prefix + 'country_id'] = int(query[prefix + 'country_id'])
+
+        if query.get(prefix + 'vat'):
+            query[prefix + 'vat_subjected'] = True
+
+        if not remove_prefix:
+            return query
+
+        return dict(
+            (field_name, data[prefix + field_name])
+            for field_name in all_fields
+            if data.get(prefix + field_name)
+        )
+
+    def validate_user_form(self, data):
+        cr, uid, registry = \
+            request.cr, request.uid, request.registry
+
+        partner_model = registry["res.partner"]
+        # Validation
+        error = {}
+        for field_name in self.mandatory_billing_fields:
+            if not data.get(field_name):
+                error[field_name] = 'missing'
+
+        if data.get("vat") and hasattr(partner_model, "check_vat"):
+            if request.website.company_id.vat_check_vies:
+                # force full VIES online check
+                check_func = partner_model.vies_vat_check
+            else:
+                # quick and partial off-line checksum validation
+                check_func = partner_model.simple_vat_check
+            vat_country, vat_number = partner_model._split_vat(data.get("vat"))
+            # simple_vat_check
+            if not check_func(cr, uid, vat_country, vat_number, context=None):
+                error["vat"] = 'error'
+
+        if data.get("shipping_id") == -1:
+            for field_name in self.mandatory_shipping_fields:
+                field_name = 'shipping_' + field_name
+                if not data.get(field_name):
+                    error[field_name] = 'missing'
+        error_messages = self.get_error_messages(error)
+        return error, error_messages
+
+    def get_error_messages(self, errors):
+        """ override this to inject your error messages
+        """
+        return {}
+
+    def save_user_form(self, user_info):
+        cr, uid, context, registry = \
+            request.cr, request.uid, request.context, request.registry
+
+        partner_model = registry.get('res.partner')
+        user_model = registry.get('res.users')
+        partner_lang = request.lang if request.lang in [
+            lang.code for lang in request.website.language_ids] else None
+
+        billing_info = {}
+        if partner_lang:
+            billing_info['lang'] = partner_lang
+        billing_info.update(self.user_info_parse('billing', user_info, True))
+
+        # set partner_id
+        partner_id = None
+        if request.uid != request.website.user_id.id:
+            partner_id = user_model.browse(cr, SUPERUSER_ID, uid,
+                                           context=context).partner_id.id
+        # save partner informations
+        partner_model.write(cr, SUPERUSER_ID, [partner_id], billing_info,
+                            context=context)
+
+        # create a new shipping partner
+        if user_info.get('shipping_id') == -1:
+            shipping_info = {}
+            if partner_lang:
+                shipping_info['lang'] = partner_lang
+            shipping_info.update(
+                self.user_info_parse('shipping', user_info, True))
+            shipping_info['type'] = 'delivery'
+            shipping_info['parent_id'] = partner_id
+            user_info['shipping_id'] = partner_model.create(
+                cr, SUPERUSER_ID, shipping_info, context)

--- a/website_sale_customer/controllers/orders.py
+++ b/website_sale_customer/controllers/orders.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from openerp import http
+from openerp.http import request
+
+
+class ShopUserOrdersController(http.Controller):
+    """ This is mainly a porting of `website_sale`
+    orders_followup controller from v9 master.
+    """
+
+    orders_followup_template = "website_sale_customer.orders_followup"
+
+    @http.route([
+        '/shop/orders',
+        '/shop/orders/page/<int:page>',
+    ], type='http', auth="user", website=True)
+    def orders_followup(self, page=1, by=5, **post):
+        partner = request.env['res.users'].browse(request.uid).partner_id
+        orders = request.env['sale.order'].sudo().search(
+            [('partner_id', '=', partner.id),
+             ('state', 'not in', ['draft', 'cancel'])])
+
+        nbr_pages = max((len(orders) / by) +
+                        (1 if len(orders) % by > 0 else 0), 1)
+        page = min(page, nbr_pages)
+        pager = request.website.pager(
+            url='/shop/orders', total=nbr_pages, page=page, step=1,
+            scope=by, url_args=post
+        )
+        orders = orders[by * (page - 1): by * (page - 1) + by]
+
+        order_invoice_lines = {}
+        for o in orders:
+            invoiced_lines = request.env['account.invoice.line'].sudo().search(
+                [('invoice_id', 'in', o.invoice_ids.ids)])
+            order_invoice_lines[o.id] = {
+                il.product_id.id: il.invoice_id
+                for il in invoiced_lines
+            }
+
+        return request.website.render(self.orders_followup_template, {
+            'orders': orders,
+            'order_invoice_lines': order_invoice_lines,
+            'pager': pager,
+        })

--- a/website_sale_customer/data/action_rules.xml
+++ b/website_sale_customer/data/action_rules.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="action_shop_partner_registered" model="ir.actions.server">
+            <field name="name">Shop partner registered</field>
+            <field name="model_id" ref="base.model_res_partner"/>
+            <field name="condition">True</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">email</field>
+            <field name="template_id" ref="website_sale_customer.email_shop_partner_registered" />
+        </record>
+
+
+        <record id="rule_shop_partner_registered" model="base.action.rule">
+            <field name="name">Shop partner registered</field>
+            <field name="model_id" ref="base.model_res_partner"/>
+            <field name="sequence">1</field>
+            <field name="kind">on_create</field>
+            <field name="server_action_ids" eval="[(6,0,[ref('action_shop_partner_registered')])]"/>
+        </record>
+
+    </data>
+</openerp>

--- a/website_sale_customer/data/emails.xml
+++ b/website_sale_customer/data/emails.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="email_shop_partner_registered" model="email.template">
+            <field name="name">Shop partner registered</field>
+            <field name="model_id" ref="base.model_res_partner"/>
+            <field name="auto_delete" eval="True"/>
+            <field name="email_from">${(object.company_id.email or 'noreply@localhost')|safe}</field>
+            <field name="partner_to">${object.id}</field>
+            <field name="lang">${object.lang}</field>
+            <field name="subject">${object.name} registered</field>
+            <field name="body_html"><![CDATA[<p>Dear ${object.name},</p>
+<p>Congrats! You have been registered.</p>
+]]></field>
+        </record>
+
+    </data>
+</openerp>

--- a/website_sale_customer/data/website.xml
+++ b/website_sale_customer/data/website.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="default_home_action" model="ir.actions.act_url">
+            <field name="name">Default user home</field>
+            <field name="target">self</field>
+            <field name="url">/shop</field>
+        </record>
+
+    </data>
+</openerp>

--- a/website_sale_customer/i18n/it.po
+++ b/website_sale_customer/i18n/it.po
@@ -142,14 +142,14 @@ msgstr "I Miei Ordini"
 #. module: website_sale_customer
 #: code:addons/website_sale_customer/controllers/account.py:13
 #, python-format
-msgid "Name"
-msgstr "Nome"
+msgid "Fullname"
+msgstr "Nome e Cognome"
 
 #. module: website_sale_customer
 #: code:addons/website_sale_customer/controllers/account.py:24
 #, python-format
-msgid "Name (Shipping)"
-msgstr "Nome (Spedizione)"
+msgid "Fullname (Shipping)"
+msgstr "Nome e Cognome (Spedizione)"
 
 #. module: website_sale_customer
 #: view:website:website_sale_customer.orders_followup

--- a/website_sale_customer/i18n/it.po
+++ b/website_sale_customer/i18n/it.po
@@ -1,0 +1,341 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* website_sale_customer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-11 10:08+0000\n"
+"PO-Revision-Date: 2015-05-11 12:10+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: website_sale_customer
+#: model:email.template,subject:website_sale_customer.email_shop_partner_registered
+msgid "${object.name} registered"
+msgstr "${object.name} registrato"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "-- Create a new address --"
+msgstr "-- Crea nuovo indirizzo --"
+
+#. module: website_sale_customer
+#: view:website:website.layout
+msgid "/shop/my-account"
+msgstr "/shop/my-account"
+
+#. module: website_sale_customer
+#: model:email.template,body_html:website_sale_customer.email_shop_partner_registered
+msgid ""
+"<p>Dear ${object.name},</p>\n"
+"<p>Congrats! You have been registered.</p>\n"
+msgstr ""
+"<p>Caro/a ${object.name},</p>\n"
+"<p>Congratulazioni! Sei stato registrato.</p>\n"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Account info updated!"
+msgstr "Informazioni account aggiornate!"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Billing Information"
+msgstr "Informazioni fattura:"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:17
+#: code:addons/website_sale_customer/controllers/account.py:28
+#, python-format
+msgid "City"
+msgstr "City"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:20
+#, python-format
+msgid "Company Name"
+msgstr "Nome Azienda"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Contact"
+msgstr "Contatto"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:18
+#: code:addons/website_sale_customer/controllers/account.py:29
+#: view:website:website_sale_customer.my_account
+#, python-format
+msgid "Country"
+msgstr "Paese"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Country..."
+msgstr "Paese..."
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Date:"
+msgstr "Data:"
+
+#. module: website_sale_customer
+#: model:ir.actions.act_url,name:website_sale_customer.default_home_action
+msgid "Default user home"
+msgstr "Home di default per l'utente"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:15
+#: code:addons/website_sale_customer/controllers/account.py:26
+#, python-format
+msgid "Email"
+msgstr "Email"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Error:"
+msgstr "Errore:"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.account_base_text_field
+msgid "Field Name"
+msgstr "Campo Nome"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.account_base_text_field
+msgid "Help text here."
+msgstr "Testo di aiuto qui."
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/models/res_users.py:12
+#, python-format
+msgid "Invalid email! Please, provide a valid and existing email."
+msgstr "Email non valida! Inserire un valore valido di un'email esistente."
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Invoices"
+msgstr "Fatture"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Invoicing Address"
+msgstr "Indirizzo Fatturazione"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.account_navbar
+msgid "My Account"
+msgstr "Il mio Account"
+
+#. module: website_sale_customer
+#: view:website:website.layout
+msgid "My Orders"
+msgstr "I Miei Ordini"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:13
+#, python-format
+msgid "Name"
+msgstr "Nome"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:24
+#, python-format
+msgid "Name (Shipping)"
+msgstr "Nome (Spedizione)"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "N°"
+msgstr "N°"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Order"
+msgstr "Ordine"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.account_navbar
+msgid "Orders"
+msgstr "Ordini"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Paid"
+msgstr "Pagato"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:14
+#: code:addons/website_sale_customer/controllers/account.py:25
+#, python-format
+msgid "Phone"
+msgstr "Telefono"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup_lines
+msgid "Product"
+msgstr "Prodotto"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup_lines
+msgid "Quantity"
+msgstr "Quantità"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Quotation"
+msgstr "Preventivo"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid ""
+"Required fields missing or some value might be wrong, please correct them."
+msgstr ""
+"Un campo obbligatorio non é stato inserito o qualche valore potrebbe non "
+"essere corretto, si prega di correggere."
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Save"
+msgstr "Salva"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Ship to the same address"
+msgstr "Consegna allo stesso indirizzo"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Shipping"
+msgstr "Spedizione"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Shipping Address"
+msgstr "Indirizzo di Spedizione"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Shipping Information"
+msgstr "Informazioni spedizione"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Shop - My account"
+msgstr "Negozio - Il Mio Account"
+
+#. module: website_sale_customer
+#: model:ir.actions.server,name:website_sale_customer.action_shop_partner_registered
+msgid "Shop partner registered"
+msgstr "Partner negozio registrato"
+
+#. module: website_sale_customer
+#: view:website:website.layout
+msgid "Sign in"
+msgstr "Accedi"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/models/res_users.py:15
+#, python-format
+msgid "Sorry, this email / login is not available. Are you already registered?"
+msgstr "Spiacenti, questa email / login non é disponibile. Sei giá registrato?"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:21
+#: code:addons/website_sale_customer/controllers/account.py:31
+#: view:website:website_sale_customer.my_account
+#, python-format
+msgid "State / Province"
+msgstr "Provincia"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "State / Province..."
+msgstr "Provincia..."
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:16
+#: code:addons/website_sale_customer/controllers/account.py:27
+#, python-format
+msgid "Street"
+msgstr "Indirizzo"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup_lines
+msgid "Subtotal"
+msgstr "Subtotale"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Taxes:"
+msgstr "Imposte:"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Total:"
+msgstr "Totale:"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup_lines
+msgid "Unit Price"
+msgstr "Prezzo unitario"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Untaxed Amount:"
+msgstr "Totale senza tasse:"
+
+#. module: website_sale_customer
+#: model:ir.model,name:website_sale_customer.model_res_users
+msgid "Users"
+msgstr "Utenti"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:22
+#, python-format
+msgid "VAT Number"
+msgstr "P.IVA"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "Waiting"
+msgstr "Attesa"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "You have yet to order anything, why not"
+msgstr "Non hai ancora ordinato nulla, perché non"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "Your Address"
+msgstr "Il tuo indirizzo"
+
+#. module: website_sale_customer
+#: code:addons/website_sale_customer/controllers/account.py:19
+#: code:addons/website_sale_customer/controllers/account.py:30
+#, python-format
+msgid "Zip / Postal code"
+msgstr "CAP"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "cancel"
+msgstr "annulla"
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.my_account
+msgid "select..."
+msgstr "seleziona..."
+
+#. module: website_sale_customer
+#: view:website:website_sale_customer.orders_followup
+msgid "start now"
+msgstr "cominciare adesso"

--- a/website_sale_customer/models/__init__.py
+++ b/website_sale_customer/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/website_sale_customer/models/res_users.py
+++ b/website_sale_customer/models/res_users.py
@@ -3,11 +3,11 @@
 from openerp import models
 from openerp import api
 from openerp.tools.translate import _
+from openerp.http import request
 
 from openerp.addons.auth_signup.res_users import SignupError
 
 from openerp.addons.website_sale_customer import utils
-
 
 INVALID_EMAIL_MSG = _("Invalid email! "
                       "Please, provide a valid and existing email.")
@@ -18,6 +18,15 @@ USER_EXISTS_MSG = _("Sorry, this email / login is not available. "
 
 class ResUsers(models.Model):
     _inherit = 'res.users'
+
+    def translate(self, cr, uid, term, context=None):
+        context = context or request.context or {}
+        translations = self.pool.get('ir.translation')
+        name = ''  # can ben empty since we are passing the source = term
+        _type = 'code'
+        lang = context.get('lang')
+        return translations._get_source(cr, uid, name, _type, lang,
+                                        source=term)
 
     def _signup_create_user(self, cr, uid, values, context=None):
         """ Override to validate data before creating user.
@@ -31,8 +40,9 @@ class ResUsers(models.Model):
         login = values.get('login')
         email = values.get('email')
         email = email or login
-        if not utils.validate_email(email):
-            raise SignupError(INVALID_EMAIL_MSG)
+        if not utils.validate_email(email, check_mx=utils.HAS_PyDNS):
+            raise SignupError(self.translate(cr, uid, INVALID_EMAIL_MSG,
+                              context=context))
         # raise proper error if user exists
         # instead of throwing
         # duplicate key value violates unique constraint
@@ -40,7 +50,8 @@ class ResUsers(models.Model):
         #        Key (login)=(LOGIN_HERE) already exists.
         ids = self.search(cr, uid, [('login', '=', login or email)])
         if ids:
-            raise SignupError(USER_EXISTS_MSG)
+            raise SignupError(self.translate(cr, uid, USER_EXISTS_MSG,
+                              context=context))
 
     def _get_default_action(self):
         return self.env.ref('website_sale_customer.default_home_action')

--- a/website_sale_customer/models/res_users.py
+++ b/website_sale_customer/models/res_users.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from openerp import models
+from openerp import api
 from openerp.tools.translate import _
 
 from openerp.addons.auth_signup.res_users import SignupError
@@ -27,3 +28,13 @@ class ResUsers(models.Model):
         email = values.get('login') or values.get('email')
         if not utils.validate_email(email):
             raise SignupError(INVALID_EMAIL_MSG)
+
+    def _get_default_action(self):
+        return self.env.ref('website_sale_customer.default_home_action')
+
+    @api.model
+    def create(self, vals):
+        if not vals.get('action_id'):
+            action = self._get_default_action()
+            vals['action_id'] = action and action.id or False
+        return super(ResUsers, self).create(vals)

--- a/website_sale_customer/models/res_users.py
+++ b/website_sale_customer/models/res_users.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models
+from openerp.tools.translate import _
+
+from openerp.addons.auth_signup.res_users import SignupError
+
+from openerp.addons.website_sale_customer import utils
+
+
+INVALID_EMAIL_MSG = _("Invalid email! "
+                      "Please, provide a valid and existing email.")
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    def _signup_create_user(self, cr, uid, values, context=None):
+        """ Override to validate data before creating user.
+        """
+
+        self._validate_signup_values(cr, uid, values, context=context)
+        return super(ResUsers, self)._signup_create_user(cr, uid, values,
+                                                         context=context)
+
+    def _validate_signup_values(self, cr, uid, values, context=None):
+        email = values.get('login') or values.get('email')
+        if not utils.validate_email(email):
+            raise SignupError(INVALID_EMAIL_MSG)

--- a/website_sale_customer/utils.py
+++ b/website_sale_customer/utils.py
@@ -1,0 +1,51 @@
+import logging
+logger = logging.getLogger(__file__)
+
+try:
+    # try to use https://pypi.python.org/pypi/validate_email
+    from validate_email import validate_email
+except ImportError:
+    msg = '"validate_email" package is missing. \
+    Install it to have better email validation.'
+    logger.warn(msg)
+
+    import re
+    EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
+
+    def validate_email(email, verify=False, check_mx=False):
+        """ fallback validation.
+        `verify` and `check_mx``are just to mimic
+        `validate_email.validate_email` signature.
+        """
+        return EMAIL_REGEX.match(email)
+
+try:
+    # improves `validate_email.validate_email` validation
+    # see https://pypi.python.org/pypi/validate_email docs
+    import DNS # noqa
+    HAS_PyDNS = True
+except ImportError:
+    msg = '"pyDNS" package is missing. \
+    Install it to have better email validation.'
+    logger.warn(msg)
+    HAS_PyDNS = False
+
+try:
+    import phonenumbers
+    from phonenumbers.phonenumberutil import NumberParseException
+
+    def validate_phonenumber(value):
+        try:
+            return bool(phonenumbers.parse(value))
+        except NumberParseException:
+            return False
+
+except ImportError:
+    msg = '"phonenumbers" package is missing. \
+    Install it to have better email validation.'
+    logger.warn(msg)
+
+    def validate_phonenumber(value):
+        if not value.isdigit():
+            return False
+        return True

--- a/website_sale_customer/view/templates_account.xml
+++ b/website_sale_customer/view/templates_account.xml
@@ -87,43 +87,43 @@
 
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'name'" />
-                      <t t-set="f_label" t-value="'Name'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                     </t>
 
                     <div t-if="has_check_vat" class="clearfix"/>
 
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'street'" />
-                      <t t-set="f_label" t-value="'Company Name'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                     </t>
 
                     <t t-if="has_check_vat">
                       <t t-call="website_sale_customer.account_base_text_field">
                         <t t-set="f_name" t-value="'vat'" />
-                        <t t-set="f_label" t-value="'VAT Number'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                       </t>
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'email'" />
-                      <t t-set="f_label" t-value="'Email'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'phone'" />
-                      <t t-set="f_label" t-value="'Phone'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'street2'" />
-                      <t t-set="f_label" t-value="'Street'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                     </t>
                     <div class="clearfix"/>
 
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'city'" />
-                      <t t-set="f_label" t-value="'City'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'zip'" />
-                      <t t-set="f_label" t-value="'Zip / Postal code'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                     </t>
                     <div t-attf-class="form-group #{mandatory_fields.get('country_id') and 'required' or ''} #{error.get('country_id') and 'has-error' or ''} col-lg-6">
                         <label class="control-label" for="country_id">Country</label>
@@ -170,27 +170,27 @@
 
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'shipping_name'" />
-                      <t t-set="f_label" t-value="'Name (Shipping)'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                       <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'shipping_phone'" />
-                      <t t-set="f_label" t-value="'Phone'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                       <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
-                      <t t-set="f_name" t-value="'shipping_street'" />
-                      <t t-set="f_label" t-value="'Street'" />
+                      <t t-set="f_name" t-value="'shipping_street2'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                       <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'shipping_city'" />
-                      <t t-set="f_label" t-value="'City'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                       <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
                     </t>
                     <t t-call="website_sale_customer.account_base_text_field">
                       <t t-set="f_name" t-value="'shipping_zip'" />
-                      <t t-set="f_label" t-value="'Zip / Postal Code'" />
+                      <t t-set="f_label" t-value="labels.get(f_name)" />
                       <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
                     </t>
                     <div t-attf-class="form-group #{mandatory_fields.get('shipping_country_id') and 'required' or ''} #{error.get('shipping_country_id') and 'has-error' or ''} col-lg-6">

--- a/website_sale_customer/view/templates_account.xml
+++ b/website_sale_customer/view/templates_account.xml
@@ -24,7 +24,7 @@
       <ul id="my-account-navbar" class="nav nav-pills">
         <li role="presentation" id="my-account"
             t-att-class="request.httprequest.path == '/shop/my-account' and 'active'">
-          <a href="/shop/my-account">Account</a>
+          <a href="/shop/my-account">My Account</a>
         </li>
       </ul>
     </div>
@@ -47,6 +47,13 @@
         <p class="help-block"
            t-raw="form_fields_helpers.get(f_name)">Help text here.</p>
       </t>
+      <div class="alert alert-danger" role="alert"
+           t-if="error.get(f_name) and error_messages.get(f_name)">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+        <span class="error-message"
+              t-esc="error_messages.get(f_name)"
+              />
+      </div>
   </div>
 </template>
 
@@ -58,6 +65,11 @@
       <div class="container oe_website_sale">
 
         <t t-call="website_sale_customer.account_navbar" />
+
+        <div class="alert alert-success" role="alert" t-if="saved">
+          <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          Account info updated!
+        </div>
 
         <h1>Your Address</h1>
         <form action="/shop/my-account" method="post">
@@ -203,7 +215,7 @@
             </div>
           </div>
           <div class="form-group">
-            <a class="btn btn-default a-submit">Save</a>
+            <a class="btn btn-primary a-submit">Save</a>
             <a class="btn btn-red"
                href="/shop/my-account">cancel</a>
           </div>

--- a/website_sale_customer/view/templates_account.xml
+++ b/website_sale_customer/view/templates_account.xml
@@ -32,6 +32,25 @@
 </template>
 
 
+<template id="account_base_text_field" name="My Account base field">
+  <div t-attf-class="form-group #{mandatory_fields.get(f_name) and 'required' or ''} #{error.get(f_name) and 'has-error' or ''} #{extra_css_class or 'col-lg-6'}">
+      <label class="control-label"
+             t-att-for="f_name"
+             t-esc="f_label">Field Name</label>
+      <input type="text"
+             class="form-control"
+             t-att-name="f_name"
+             t-att-readonly="f_readonly or ''"
+             t-att-value="user_info.get(f_name)"
+             />
+      <t t-if="form_fields_helpers.get(f_name)">
+        <p class="help-block"
+           t-raw="form_fields_helpers.get(f_name)">Help text here.</p>
+      </t>
+  </div>
+</template>
+
+
 <template id="my_account">
   <t t-call="website.layout">
     <t t-set="additional_title">Shop - My account</t>
@@ -53,51 +72,47 @@
             <div class="col-md-8 oe_customer_account">
                 <h3 class="page-header mt16">Billing Information</h3>
                 <div class="row">
-                    <div t-attf-class="form-group #{mandatory_fields.get('name') and 'required' or ''} #{error.get('name') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="contact_name">Your Name</label>
-                        <input type="text" name="name"
-                          class="form-control" t-att-value="user_info.get('name')"/>
-                        <t t-if="form_fields_helpers.get('name')">
-                          <p class="help-block"
-                             t-raw="form_fields_helpers.get('name')">Help text here.</p>
-                        </t>
-                    </div>
-                    <div t-if="has_check_vat" class="clearfix"/>
-                    <div t-attf-class="form-group #{mandatory_fields.get('street') and 'required' or ''} #{error.get('street') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="street">Company Name</label>
-                        <input type="text" name="street" class="form-control" t-att-value="user_info.get('street')"/>
-                    </div>
-                    <div t-if="has_check_vat" t-attf-class="form-group #{mandatory_fields.get('vat') and 'required' or ''} #{error.get('vat') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="vat">VAT Number</label>
-                        <input type="text" name="vat" class="form-control" t-att-value="user_info.get('vat')"/>
-                        <t t-if="form_fields_helpers.get('vat')">
-                          <p class="help-block"
-                             t-raw="form_fields_helpers.get('vat')">Help text here.</p>
-                        </t>
-                    </div>
-                    <div t-attf-class="form-group #{mandatory_fields.get('email') and 'required' or ''} #{error.get('email') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="contact_name">Email</label>
-                        <input type="email" name="email" class="form-control" t-att-value="user_info.get('email')"/>
-                    </div>
-                    <div t-attf-class="form-group #{mandatory_fields.get('phone') and 'required' or ''} #{error.get('phone') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="phone">Phone</label>
-                        <input type="tel" name="phone" class="form-control" t-att-value="user_info.get('phone')"/>
-                    </div>
 
-                    <div t-attf-class="form-group #{mandatory_fields.get('street2') and 'required' or ''} #{error.get('street2') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="street2">Street</label>
-                        <input type="text" name="street2" class="form-control" t-att-value="user_info.get('street2')"/>
-                    </div>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'name'" />
+                      <t t-set="f_label" t-value="'Name'" />
+                    </t>
+
+                    <div t-if="has_check_vat" class="clearfix"/>
+
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'street'" />
+                      <t t-set="f_label" t-value="'Company Name'" />
+                    </t>
+
+                    <t t-if="has_check_vat">
+                      <t t-call="website_sale_customer.account_base_text_field">
+                        <t t-set="f_name" t-value="'vat'" />
+                        <t t-set="f_label" t-value="'VAT Number'" />
+                      </t>
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'email'" />
+                      <t t-set="f_label" t-value="'Email'" />
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'phone'" />
+                      <t t-set="f_label" t-value="'Phone'" />
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'street2'" />
+                      <t t-set="f_label" t-value="'Street'" />
+                    </t>
                     <div class="clearfix"/>
 
-                    <div t-attf-class="form-group #{mandatory_fields.get('city') and 'required' or ''} #{error.get('city') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="city">City</label>
-                        <input type="text" name="city" class="form-control" t-att-value="user_info.get('city')"/>
-                    </div>
-                    <div t-attf-class="form-group #{mandatory_fields.get('zip') and 'required' or ''} #{error.get('zip') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="zip">Zip / Postal Code</label>
-                        <input type="text" name="zip" class="form-control" t-att-value="user_info.get('zip')"/>
-                    </div>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'city'" />
+                      <t t-set="f_label" t-value="'City'" />
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'zip'" />
+                      <t t-set="f_label" t-value="'Zip / Postal code'" />
+                    </t>
                     <div t-attf-class="form-group #{mandatory_fields.get('country_id') and 'required' or ''} #{error.get('country_id') and 'has-error' or ''} col-lg-6">
                         <label class="control-label" for="country_id">Country</label>
                         <select name="country_id" class="form-control">
@@ -141,27 +156,31 @@
                 <div class="js_shipping row mb16" t-att-style="not shipping_id and 'display:none' or ''">
                     <h3 class="oe_shipping col-lg-12 mt16">Shipping Information</h3>
 
-                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_name') and 'required' or ''} #{error.get('shipping_name') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="shipping_name">Name (Shipping)</label>
-                        <input type="text" name="shipping_name" class="form-control" t-att-value="user_info.get('shipping_name', '')" t-att-readonly="'readonly' if shipping_id &gt;= 0 else ''"/>
-                    </div>
-                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_phone') and 'required' or ''} #{error.get('shipping_phone') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="shipping_phone">Phone</label>
-                        <input type="tel" name="shipping_phone" class="form-control" t-att-value="user_info.get('shipping_phone', '')" t-att-readonly="  'readonly' if shipping_id &gt;= 0 else ''"/>
-                    </div>
-                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_street') and 'required' or ''} #{error.get('shipping_street') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="shipping_street">Street</label>
-                        <input type="text" name="shipping_street" class="form-control" t-att-value="user_info.get('shipping_street', '')" t-att-readonly=" 'readonly' if shipping_id &gt;= 0 else ''"/>
-                    </div>
-                    <div class="clearfix"/>
-                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_city') and 'required' or ''} #{error.get('shipping_city') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="shipping_city">City</label>
-                        <input type="text" name="shipping_city" class="form-control" t-att-value="user_info.get('shipping_city', '')" t-att-readonly=" 'readonly' if shipping_id &gt;= 0 else ''"/>
-                    </div>
-                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_zip') and 'required' or ''} #{error.get('shipping_zip') and 'has-error' or ''} col-lg-6">
-                        <label class="control-label" for="shipping_zip">Zip / Postal Code</label>
-                        <input type="text" name="shipping_zip" class="form-control" t-att-value="user_info.get('shipping_zip', '')" t-att-readonly=" 'readonly' if shipping_id &gt;= 0 else ''"/>
-                    </div>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'shipping_name'" />
+                      <t t-set="f_label" t-value="'Name (Shipping)'" />
+                      <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'shipping_phone'" />
+                      <t t-set="f_label" t-value="'Phone'" />
+                      <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'shipping_street'" />
+                      <t t-set="f_label" t-value="'Street'" />
+                      <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'shipping_city'" />
+                      <t t-set="f_label" t-value="'City'" />
+                      <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
+                    </t>
+                    <t t-call="website_sale_customer.account_base_text_field">
+                      <t t-set="f_name" t-value="'shipping_zip'" />
+                      <t t-set="f_label" t-value="'Zip / Postal Code'" />
+                      <t t-set="f_readonly" t-value="'readonly' if shipping_id &gt;= 0 else ''" />
+                    </t>
                     <div t-attf-class="form-group #{mandatory_fields.get('shipping_country_id') and 'required' or ''} #{error.get('shipping_country_id') and 'has-error' or ''} col-lg-6">
                         <label class="control-label" for="shipping_country_id">Country</label>
                         <select name="shipping_country_id" class="form-control" t-att-disabled="  'disabled' if shipping_id &gt;= 0 else ''">

--- a/website_sale_customer/view/templates_account.xml
+++ b/website_sale_customer/view/templates_account.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+<!-- redirect to account after main login -->
+  <!-- <xpath expr="//a[@t-attf-href='/web/login']" position="attributes">
+    <attribute name="t-attf-class">/web/login?redirect=/shop/my-account</attribute>
+  </xpath> -->
+<template id="show_sign_in" inherit_id="website.layout">
+  <xpath expr="//ul[@id='top_menu']" position="inside">
+    <li class="divider"/>
+    <li>
+      <a t-attf-href="/web/login?redirect=/shop/my-account">
+        <b>Sign in</b>
+      </a>
+    </li>
+  </xpath>
+</template>
+
+
+<template id="account_navbar" name="Navbar for My account page">
+  <div class="row">
+    <div class="col-md-12">
+      <ul id="my-account-navbar" class="nav nav-pills">
+        <li role="presentation" id="my-account"
+            t-att-class="request.httprequest.path == '/shop/my-account' and 'active'">
+          <a href="/shop/my-account">Account</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+
+<template id="my_account">
+  <t t-call="website.layout">
+    <t t-set="additional_title">Shop - My account</t>
+    <div id="wrap">
+      <div class="container oe_website_sale">
+
+        <t t-call="website_sale_customer.account_navbar" />
+
+        <h1>Your Address</h1>
+        <form action="/shop/my-account" method="post">
+
+          <div class="alert alert-danger" role="alert" t-if="error">
+            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+            <span class="sr-only">Error:</span>
+            Required fields missing or some value might be wrong, please correct them.
+          </div>
+
+          <div class="row">
+            <div class="col-md-8 oe_customer_account">
+                <h3 class="page-header mt16">Billing Information</h3>
+                <div class="row">
+                    <div t-attf-class="form-group #{mandatory_fields.get('name') and 'required' or ''} #{error.get('name') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="contact_name">Your Name</label>
+                        <input type="text" name="name"
+                          class="form-control" t-att-value="user_info.get('name')"/>
+                        <t t-if="form_fields_helpers.get('name')">
+                          <p class="help-block"
+                             t-raw="form_fields_helpers.get('name')">Help text here.</p>
+                        </t>
+                    </div>
+                    <div t-if="has_check_vat" class="clearfix"/>
+                    <div t-attf-class="form-group #{mandatory_fields.get('street') and 'required' or ''} #{error.get('street') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="street">Company Name</label>
+                        <input type="text" name="street" class="form-control" t-att-value="user_info.get('street')"/>
+                    </div>
+                    <div t-if="has_check_vat" t-attf-class="form-group #{mandatory_fields.get('vat') and 'required' or ''} #{error.get('vat') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="vat">VAT Number</label>
+                        <input type="text" name="vat" class="form-control" t-att-value="user_info.get('vat')"/>
+                        <t t-if="form_fields_helpers.get('vat')">
+                          <p class="help-block"
+                             t-raw="form_fields_helpers.get('vat')">Help text here.</p>
+                        </t>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('email') and 'required' or ''} #{error.get('email') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="contact_name">Email</label>
+                        <input type="email" name="email" class="form-control" t-att-value="user_info.get('email')"/>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('phone') and 'required' or ''} #{error.get('phone') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="phone">Phone</label>
+                        <input type="tel" name="phone" class="form-control" t-att-value="user_info.get('phone')"/>
+                    </div>
+
+                    <div t-attf-class="form-group #{mandatory_fields.get('street2') and 'required' or ''} #{error.get('street2') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="street2">Street</label>
+                        <input type="text" name="street2" class="form-control" t-att-value="user_info.get('street2')"/>
+                    </div>
+                    <div class="clearfix"/>
+
+                    <div t-attf-class="form-group #{mandatory_fields.get('city') and 'required' or ''} #{error.get('city') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="city">City</label>
+                        <input type="text" name="city" class="form-control" t-att-value="user_info.get('city')"/>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('zip') and 'required' or ''} #{error.get('zip') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="zip">Zip / Postal Code</label>
+                        <input type="text" name="zip" class="form-control" t-att-value="user_info.get('zip')"/>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('country_id') and 'required' or ''} #{error.get('country_id') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="country_id">Country</label>
+                        <select name="country_id" class="form-control">
+                            <option value="">Country...</option>
+                            <t t-foreach="countries or []" t-as="country">
+                                <option t-att-value="country.id" t-att-selected="country.id == user_info.get('country_id')"><t t-esc="country.name"/></option>
+                            </t>
+                        </select>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('state_id') and 'required' or ''} #{error.get('state_id') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="state_id">State / Province</label>
+                        <select name="state_id" class="form-control">
+                            <option value="">select...</option>
+                            <t t-foreach="states or []" t-as="state">
+                                <option t-att-value="state.id" style="display:none;" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == user_info.get('state_id')"><t t-esc="state.name"/></option>
+                            </t>
+                        </select>
+                    </div>
+
+                    <div class="clearfix"/>
+
+                    <div class="form-group col-lg-12">
+                        <label>Shipping</label>
+                        <select name="shipping_id" class="form-control">
+                            <option value="0">Ship to the same address</option>
+                            <t t-foreach="shippings" t-as="shipping">
+                                <option t-att-value="shipping.id" t-att-selected="shipping.id == shipping_id"
+                                  t-att-data-shipping_name="shipping.name"
+                                  t-att-data-shipping_phone="shipping.phone"
+                                  t-att-data-shipping_street="shipping.street"
+                                  t-att-data-shipping_city="shipping.city"
+                                  t-att-data-shipping_zip="shipping.zip"
+                                  t-att-data-shipping_state_id="shipping.state_id and shipping.state_id.id"
+                                  t-att-data-shipping_country_id="shipping.country_id and shipping.country_id.id"
+                                  ><t t-esc="', '.join('\n'.join(shipping.name_get()[0][1].split(',')).split('\n')[1:])"/></option>
+                            </t>
+                            <option value="-1" t-att-selected="error and len(error) > 0 and shipping_id == -1">-- Create a new address --</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="js_shipping row mb16" t-att-style="not shipping_id and 'display:none' or ''">
+                    <h3 class="oe_shipping col-lg-12 mt16">Shipping Information</h3>
+
+                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_name') and 'required' or ''} #{error.get('shipping_name') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="shipping_name">Name (Shipping)</label>
+                        <input type="text" name="shipping_name" class="form-control" t-att-value="user_info.get('shipping_name', '')" t-att-readonly="'readonly' if shipping_id &gt;= 0 else ''"/>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_phone') and 'required' or ''} #{error.get('shipping_phone') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="shipping_phone">Phone</label>
+                        <input type="tel" name="shipping_phone" class="form-control" t-att-value="user_info.get('shipping_phone', '')" t-att-readonly="  'readonly' if shipping_id &gt;= 0 else ''"/>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_street') and 'required' or ''} #{error.get('shipping_street') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="shipping_street">Street</label>
+                        <input type="text" name="shipping_street" class="form-control" t-att-value="user_info.get('shipping_street', '')" t-att-readonly=" 'readonly' if shipping_id &gt;= 0 else ''"/>
+                    </div>
+                    <div class="clearfix"/>
+                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_city') and 'required' or ''} #{error.get('shipping_city') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="shipping_city">City</label>
+                        <input type="text" name="shipping_city" class="form-control" t-att-value="user_info.get('shipping_city', '')" t-att-readonly=" 'readonly' if shipping_id &gt;= 0 else ''"/>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_zip') and 'required' or ''} #{error.get('shipping_zip') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="shipping_zip">Zip / Postal Code</label>
+                        <input type="text" name="shipping_zip" class="form-control" t-att-value="user_info.get('shipping_zip', '')" t-att-readonly=" 'readonly' if shipping_id &gt;= 0 else ''"/>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_country_id') and 'required' or ''} #{error.get('shipping_country_id') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="shipping_country_id">Country</label>
+                        <select name="shipping_country_id" class="form-control" t-att-disabled="  'disabled' if shipping_id &gt;= 0 else ''">
+                            <option value="">Country...</option>
+                            <t t-foreach="countries or []" t-as="country">
+                                <option t-att-value="country.id" t-att-selected="country.id == user_info.get('shipping_country_id')"><t t-esc="country.name"/></option>
+                            </t>
+                        </select>
+                    </div>
+                    <div t-attf-class="form-group #{mandatory_fields.get('shipping_state_id') and 'required' or ''} #{error.get('shipping_state_id') and 'has-error' or ''} col-lg-6">
+                        <label class="control-label" for="shipping_state_id">State / Province</label>
+                        <select name="shipping_state_id" class="form-control" t-att-readonly="  'readonly' if shipping_id &gt;= 0 else ''">
+                            <option value="">State / Province...</option>
+                            <t t-foreach="states or []" t-as="state">
+                                <option t-att-value="state.id" style="display:none;" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == user_info.get('shipping_state_id')"><t t-esc="state.name"/></option>
+                            </t>
+                        </select>
+                    </div>
+                </div>
+            </div>
+          </div>
+          <div class="form-group">
+            <a class="btn btn-default a-submit">Save</a>
+            <a class="btn btn-red"
+               href="/shop/my-account">cancel</a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </t>
+</template>
+
+<template id="my_account_link_update"
+  name="My account link update"
+  inherit_id="website.layout">
+
+  <xpath expr="//li[@class='dropdown']/ul/li[contains(.,'My Account')]/a"
+    position="attributes">
+    <attribute name="href">/shop/my-account</attribute>
+  </xpath>
+
+</template>
+
+    </data>
+</openerp>

--- a/website_sale_customer/view/templates_orders.xml
+++ b/website_sale_customer/view/templates_orders.xml
@@ -44,116 +44,126 @@
 
         <t t-call="website_sale_customer.orders_followup_navbar"/>
 
-        <t t-foreach="orders" t-as="o">
-          <div class='row'>
+        <div id="accordion" class="panel-group" role="tablist" aria-multiselectable="true">
+          <t t-foreach="orders" t-as="o">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <div class="row">
-                  <div class="col-md-12">
-                    <h4>
-                      <t t-if="o.state == 'sent'">
-                        Quotation N°
-                      </t>
-                      <t t-if="o.state != 'sent'">
-                        Order N°
-                      </t>
-                      <span t-field="o.name"/>
-                    </h4>
-                  </div>
-                </div>
+              <div class="panel-heading" role="tab" t-attf-id="heading-order-#{o.id}">
+                <h4 class="panel-title">
+                  <a data-toggle="collapse" data-parent="#accordion"
+                     t-attf-href="#content-order-#{o.id}" aria-expanded="true" aria-controls="collapseOne">
+                    <t t-if="o.state == 'sent'">
+                      <strong>Quotation</strong> N°
+                    </t>
+                    <t t-if="o.state != 'sent'">
+                      <strong>Order</strong> N°
+                    </t>
+                    <span class="order-name" t-field="o.name"/>
+                    -
+                    <span class="order-date">
+                      <strong>Date:</strong>
+                      <span t-field="o.create_date" t-field-options='{"widget": "date"}'/>
+                    </span>
+                  </a>
+                </h4>
               </div>
-              <div class="panel-body">
-                <!-- <hr/> -->
-                <div class="mb8">
-                    <strong>Date:</strong> <span t-field="o.create_date" t-field-options='{"widget": "date"}'/>
-                </div>
-                <div class='row'>
-                  <div class="col-md-6">
-                    <div>
-                      <strong>Invoicing Address</strong>
-                    </div>
-                    <div>
-                      <address t-field="o.partner_invoice_id" t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
-                    </div>
-                    <t t-set="invoices" t-value="[i for i in o.invoice_ids if i.state not in ['draft', 'cancel']]"/>
-                    <t t-if="invoices">
+              <div class="panel-collapse collapse" role="tabpanel"
+                   t-attf-id="content-order-#{o.id}">
+                <div class="panel-body">
+                  <div class="row">
+                    <div class="col-md-4 invoice-address">
+                      <h5><strong>Invoicing Address</strong></h5>
                       <div>
-                        <strong>Invoices</strong>
+                        <address t-field="o.partner_invoice_id" t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
                       </div>
-                      <div>
-                        <t t-foreach="invoices" t-as="i">
-                          <t t-set="report_url" t-value="'/report/pdf/account.report_invoice/%s' % i.id"/>
-                          <div>
-                            <a t-att-href="report_url"><span class="fa fa-download"/></a>
-                            <a t-att-href="report_url"><span t-field="i.number"/></a>
-                            <span class="text-muted" t-field="i.date_invoice"/>
-                            <t t-if="i.state == 'paid'">
-                              <span class="label label-success orders_label_text_align"><i class="fa fa-fw fa-check"/> Paid</span>
-                            </t>
-                            <t t-if="i.state != 'paid'">
-                              <span class="label label-info orders_label_text_align"><i class="fa fa-fw fa-clock-o"/> Waiting</span>
-                            </t>
-                          </div>
-                        </t>
+                    </div>
+                    <t t-set="invoices"
+                       t-value="[i for i in o.invoice_ids if i.state not in ['draft', 'cancel']]" />
+                    <t t-if="invoices">
+                      <div class="col-md-4 invoices">
+                        <h5><strong>Invoices</strong></h5>
+                        <div>
+                          <t t-foreach="invoices" t-as="i">
+                            <t t-set="report_url" t-value="'/report/pdf/account.report_invoice/%s' % i.id"/>
+                            <div>
+                              <a t-att-href="report_url"><span class="fa fa-download"/></a>
+                              <a t-att-href="report_url"><span t-field="i.number"/></a>
+                              <span class="text-muted" t-field="i.date_invoice"/>
+                              <t t-if="i.state == 'paid'">
+                                <span class="label label-success orders_label_text_align">
+                                  <i class="fa fa-fw fa-check"/> Paid
+                                </span>
+                              </t>
+                              <t t-if="i.state != 'paid'">
+                                <span class="label label-info orders_label_text_align">
+                                  <i class="fa fa-fw fa-clock-o"/> Waiting
+                                </span>
+                              </t>
+                            </div>
+                          </t>
+                        </div>
                       </div>
                     </t>
-                  </div>
-                  <div id="shipping_address" class="col-md-6">
-                    <div>
-                      <strong>Shipping Address</strong>
-                    </div>
-                    <div>
-                      <address t-field="o.partner_shipping_id" t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                    <div class="col-md-4 shipping-address">
+                      <h5><strong>Shipping Address</strong></h5>
+                      <div>
+                        <address t-field="o.partner_shipping_id" t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                <hr/>
+                  <hr/>
 
-                <div id="order_lines">
-                  <t t-call="website_sale_customer.orders_followup_lines" />
-                </div>
-
-                <hr/>
-
-                <div class="row">
-                  <div class="col-md-6">
-                    <div>
-                      <strong>Contact</strong>
-                    </div>
-                    <div t-field="o.user_id.partner_id" t-field-options='{"widget": "contact", "fields": ["email", "phone"]}'/>
+                  <div id="order_lines">
+                    <t t-call="website_sale_customer.orders_followup_lines" />
                   </div>
-                  <div class="col-md-6">
-                    <div class="row">
-                      <div class="col-md-10 text-right">
-                        Untaxed Amount:
+
+                  <hr/>
+
+                  <div class="row">
+                    <div class="col-md-6">
+                      <div>
+                        <strong>Contact</strong>
                       </div>
-                      <div class="col-md-2 text-right">
-                        <span t-field="o.amount_untaxed" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
-                      </div>
+                      <div t-field="o.user_id.partner_id"
+                           t-field-options='{"widget": "contact", "fields": ["email", "phone"]}'/>
                     </div>
-                    <div class="row">
-                      <div class="col-md-10 text-right">
-                        Taxes:
+                    <div class="col-md-6">
+                      <div class="row">
+                        <div class="col-md-10 text-right">
+                          Untaxed Amount:
+                        </div>
+                        <div class="col-md-2 text-right">
+                          <span t-field="o.amount_untaxed"
+                                t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+                        </div>
                       </div>
-                      <div class="col-md-2 text-right">
-                        <span t-field="o.amount_tax" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+                      <div class="row">
+                        <div class="col-md-10 text-right">
+                          Taxes:
+                        </div>
+                        <div class="col-md-2 text-right">
+                          <span t-field="o.amount_tax"
+                                t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+                        </div>
                       </div>
-                    </div>
-                    <div class="row">
-                      <div class="col-md-10 text-right">
-                        <strong>Total:</strong>
-                      </div>
-                      <div class="col-md-2 text-right">
-                        <strong><span t-field="o.amount_total" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/></strong>
+                      <div class="row">
+                        <div class="col-md-10 text-right">
+                          <strong>Total:</strong>
+                        </div>
+                        <div class="col-md-2 text-right">
+                          <strong>
+                            <span t-field="o.amount_total"
+                                  t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+                          </strong>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </t>
+          </t>
+        </div>
 
         <t t-if="len(orders) >= 2">
           <t t-call="website_sale_customer.orders_followup_navbar"/>

--- a/website_sale_customer/view/templates_orders.xml
+++ b/website_sale_customer/view/templates_orders.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+<!-- add menu item to account navbar -->
+<template
+    id="account_navbar_orders"
+    inherit_id="website_sale_customer.account_navbar">
+  <xpath expr="//li[@id='my-account']" position="after">
+    <li role="presentation" id="my-orders"
+        t-att-class="request.httprequest.path == '/shop/orders' and 'active'">
+      <a href="/shop/orders">
+        Orders
+      </a>
+    </li>
+  </xpath>
+</template>
+
+
+<template id="orders_followup_navbar" name="Navbar for My Orders page">
+  <div class="row">
+    <div class="col-md-12">
+      <span class="pull-right">
+        <t t-call="website.pager"/>
+      </span>
+    </div>
+  </div>
+</template>
+
+
+<template id="orders_followup" name="Odoo - Follow your Orders">
+  <t t-call="website.layout">
+    <div id="wrap">
+
+      <div class="container oe_website_sale">
+
+        <t t-call="website_sale_customer.account_navbar" />
+
+        <t t-if="not orders">
+          <h4 class="text-muted text-center mt64 mb64">
+            You have yet to order anything, why not <a href="/shop/">start now</a> ?
+          </h4>
+        </t>
+
+        <t t-call="website_sale_customer.orders_followup_navbar"/>
+
+        <t t-foreach="orders" t-as="o">
+          <div class='row'>
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <div class="row">
+                  <div class="col-md-12">
+                    <h4>
+                      <t t-if="o.state == 'sent'">
+                        Quotation N°
+                      </t>
+                      <t t-if="o.state != 'sent'">
+                        Order N°
+                      </t>
+                      <span t-field="o.name"/>
+                    </h4>
+                  </div>
+                </div>
+              </div>
+              <div class="panel-body">
+                <!-- <hr/> -->
+                <div class="mb8">
+                    <strong>Date:</strong> <span t-field="o.create_date" t-field-options='{"widget": "date"}'/>
+                </div>
+                <div class='row'>
+                  <div class="col-md-6">
+                    <div>
+                      <strong>Invoicing Address</strong>
+                    </div>
+                    <div>
+                      <address t-field="o.partner_invoice_id" t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                    </div>
+                    <t t-set="invoices" t-value="[i for i in o.invoice_ids if i.state not in ['draft', 'cancel']]"/>
+                    <t t-if="invoices">
+                      <div>
+                        <strong>Invoices</strong>
+                      </div>
+                      <div>
+                        <t t-foreach="invoices" t-as="i">
+                          <t t-set="report_url" t-value="'/report/pdf/account.report_invoice/%s' % i.id"/>
+                          <div>
+                            <a t-att-href="report_url"><span class="fa fa-download"/></a>
+                            <a t-att-href="report_url"><span t-field="i.number"/></a>
+                            <span class="text-muted" t-field="i.date_invoice"/>
+                            <t t-if="i.state == 'paid'">
+                              <span class="label label-success orders_label_text_align"><i class="fa fa-fw fa-check"/> Paid</span>
+                            </t>
+                            <t t-if="i.state != 'paid'">
+                              <span class="label label-info orders_label_text_align"><i class="fa fa-fw fa-clock-o"/> Waiting</span>
+                            </t>
+                          </div>
+                        </t>
+                      </div>
+                    </t>
+                  </div>
+                  <div id="shipping_address" class="col-md-6">
+                    <div>
+                      <strong>Shipping Address</strong>
+                    </div>
+                    <div>
+                      <address t-field="o.partner_shipping_id" t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                    </div>
+                  </div>
+                </div>
+
+                <hr/>
+
+                <div id="order_lines">
+                  <t t-call="website_sale_customer.orders_followup_lines" />
+                </div>
+
+                <hr/>
+
+                <div class="row">
+                  <div class="col-md-6">
+                    <div>
+                      <strong>Contact</strong>
+                    </div>
+                    <div t-field="o.user_id.partner_id" t-field-options='{"widget": "contact", "fields": ["email", "phone"]}'/>
+                  </div>
+                  <div class="col-md-6">
+                    <div class="row">
+                      <div class="col-md-10 text-right">
+                        Untaxed Amount:
+                      </div>
+                      <div class="col-md-2 text-right">
+                        <span t-field="o.amount_untaxed" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col-md-10 text-right">
+                        Taxes:
+                      </div>
+                      <div class="col-md-2 text-right">
+                        <span t-field="o.amount_tax" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col-md-10 text-right">
+                        <strong>Total:</strong>
+                      </div>
+                      <div class="col-md-2 text-right">
+                        <strong><span t-field="o.amount_total" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/></strong>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </t>
+
+        <t t-if="len(orders) >= 2">
+          <t t-call="website_sale_customer.orders_followup_navbar"/>
+        </t>
+
+      </div>
+      <div class="oe_structure mb32"/>
+    </div>
+  </t>
+</template>
+
+
+<template id="orders_followup_lines"
+  name="Customer order lines">
+  <div class="row">
+    <div class="col-md-8 col-md-offset-1">
+      <strong>Product</strong>
+    </div>
+    <div class="col-md-1 text-right">
+      <strong>Unit Price</strong>
+    </div>
+    <div class="col-md-1 text-right">
+      <strong>Quantity</strong>
+    </div>
+    <div class="col-md-1 text-right">
+      <strong>Subtotal</strong>
+    </div>
+  </div>
+  <t t-foreach="o.order_line" t-as="ol">
+    <div class="row orders_vertical_align">
+      <div class="col-md-1 text-center">
+        <a t-att-href="'/shop/product/%s' % str(ol.product_id.product_tmpl_id.id)">
+          <img t-att-src="'/website/image/product.product/%s/image_small/48x48' % ol.product_id.id"/>
+        </a>
+      </div>
+      <div id='product_name' class="col-md-8">
+        <a t-att-href="'/shop/product/%s' % str(ol.product_id.product_tmpl_id.id)"><span t-field="ol.product_id.name"/></a>
+      </div>
+      <div class="col-md-1 text-right">
+        <span t-field="ol.price_unit" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+      </div>
+      <div class="col-md-1 text-right">
+        <t t-if="ol._name == 'sale.order.line'">
+          <span t-field="ol.product_uom_qty"/>
+        </t>
+        <t t-if="ol._name == 'account.invoice.line'">
+          <span t-field="ol.quantity"/>
+        </t>
+      </div>
+      <div class="col-md-1 text-right">
+        <span t-field="ol.price_subtotal" t-field-options='{"widget": "monetary", "display_currency": "o.company_id.currency_id"}'/>
+      </div>
+    </div>
+  </t>
+</template>
+
+
+<template id="orders_followup_link"
+  name="Orders Link from User Account"
+  inherit_id="website_sale_customer.my_account_link_update">
+  <xpath expr="//li[@class='dropdown']/ul/li[contains(.,'Logout')]" position="before">
+    <li><a href="/shop/orders" role="menuitem">My Orders</a></li>
+  </xpath>
+</template>
+
+
+  </data>
+</openerp>


### PR DESCRIPTION
This PR  adds a module `website_sale_customer` that adds proper customer views to your shop.
It starts as a port of the improvements done on odoo 9 but it gives you more.

The customer has 2 new items in his/her personal menu: `my account` and `my orders`.

The 1st one allows the customer to edit his/her data with a form that validates the inputs and that ease overrides of validation and other stuff.

The second view allows the customer to view his/her orders without having to deal w/ odoo backend.
