### PR TITLE
[FIX] website_sale_vat_required: error when checking out with logged user:

### DIFF
--- a/website_sale_vat_required/website_order_view.xml
+++ b/website_sale_vat_required/website_order_view.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
 <data>
-    <template id="saas_users" inherit_id="website_sale.checkout">
-        <label class="control-label" for="vat" position="attributes">
+    <template id="vat_checkout" inherit_id="website_sale.checkout">
+        <xpath expr="//div[@class='container oe_website_sale']/form/div[@class='row']/div[@class='col-md-8 oe_cart']/div[@class='row']/div[4]/label" position="attributes">
             <attribute name="style"></attribute>
-        </label>
+        </xpath>
     </template>
 </data>
 </openerp>


### PR DESCRIPTION
Element '<label class="control-label" for="vat" data-oe-id="1725" data-oe-source-id="1506" data-oe-xpath="/data/label" data-oe-model="ir.ui.view" data-oe-field="arch">' cannot be located in parent view
