### PR TITLE
[FIX] mailto links in default legal pages is malformed

### DIFF
--- a/website_legal_page/views/website_legal.xml
+++ b/website_legal_page/views/website_legal.xml
@@ -66,7 +66,7 @@
                   </t>
                   <t t-if="res_company.email">
                     <li>Email address:
-                      <a t-attf-href="'mailto:' + res_company.email">
+                      <a t-attf-href="mailto:#{res_company.email}">
                         <span t-field="res_company.email"/>
                       </a>
                     </li>

--- a/website_legal_page/views/website_privacy.xml
+++ b/website_legal_page/views/website_privacy.xml
@@ -186,7 +186,7 @@
                       </t>
                       <t t-if="res_company.email">
                         <li>Email address:
-                          <a t-attf-href="'mailto:' + res_company.email">
+                          <a t-attf-href="mailto:#{res_company.email}">
                             <span t-field="res_company.email"/>
                           </a>
                         </li>

--- a/website_legal_page/views/website_terms.xml
+++ b/website_legal_page/views/website_terms.xml
@@ -191,7 +191,7 @@
                       </t>
                       <t t-if="res_company.email">
                         <li>Email address:
-                          <a t-attf-href="'mailto:' + res_company.email">
+                          <a t-attf-href="mailto:#{res_company.email}">
                             <span t-field="res_company.email"/>
                           </a>
                         </li>


### PR DESCRIPTION
This fix malformed urlinks in default legal pages:
