### PR TITLE
Cookie notice translate and simpler controller

### DIFF
--- a/website_cookie_notice/README.rst
+++ b/website_cookie_notice/README.rst
@@ -38,6 +38,8 @@ Contributors
 ------------
 
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+* Rafael Blasco <rafabn@antiun.com>
+* Jairo Llopis <yajo.sk8@gmail.com>
 
 Maintainer
 ----------

--- a/website_cookie_notice/controllers/main.py
+++ b/website_cookie_notice/controllers/main.py
@@ -22,22 +22,6 @@
 from openerp.addons.web import http
 from openerp.http import request
 
-CONFIG_FIELDS = [
-    'cookieAnalytics',
-    'cookieMessage',
-    'cookiePolicyLink',
-    'cookieOverlayEnabled',
-    'cookieAnalyticsMessage',
-    'cookieErrorMessage',
-    'cookieDeclineButton',
-    'cookieAcceptButton',
-    'cookieResetButton',
-    'cookieWhatAreTheyLink',
-    'cookieAcceptButtonText',
-    'cookieDeclineButtonText',
-    'cookieResetButtonText',
-    ]
-
 
 class CookieNotice(http.Controller):
     @http.route(
@@ -51,6 +35,7 @@ class CookieNotice(http.Controller):
         company_id = user_model._get_company(cr, uid, context)
         company = company_model.browse(cr, uid, company_id, context)
         res = {}
-        for field in CONFIG_FIELDS:
-            res[field] = getattr(company, field)
+        for field in dir(company):
+            if field.startswith("cookie"):
+                res[field] = getattr(company, field)
         return res

--- a/website_cookie_notice/i18n/es.po
+++ b/website_cookie_notice/i18n/es.po
@@ -1,25 +1,41 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* website_cookie_notice
+# 	* website_cookie_notice
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-23 19:38+0000\n"
-"PO-Revision-Date: 2015-06-23 19:38+0000\n"
+"POT-Creation-Date: 2015-10-16 16:06+0200\n"
+"PO-Revision-Date: 2015-10-16 16:06+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 1.8.5\n"
 
 #. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:67
-#, python-format
-msgid "ACCEPT COOKIES"
-msgstr "ACEPTAR"
+#: field:res.company,cookieAcceptButton:0
+msgid "Accept button"
+msgstr "Botón de aceptar"
+
+#. module: website_cookie_notice
+#: field:res.company,cookieAcceptButtonText:0
+msgid "Accept button text"
+msgstr "Texto del botón de aceptar"
+
+#. module: website_cookie_notice
+#: field:res.company,cookieAnalytics:0
+msgid "Analytics"
+msgstr "Analíticas"
+
+#. module: website_cookie_notice
+#: field:res.company,cookieAnalyticsMessage:0
+msgid "Analytics message"
+msgstr "Mensaje de analíticas"
 
 #. module: website_cookie_notice
 #: model:ir.model,name:website_cookie_notice.model_res_company
@@ -32,118 +48,105 @@ msgid "Cookie notice"
 msgstr "Aviso de uso de cookies"
 
 #. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:70
-#, python-format
-msgid "DECLINE COOKIES"
-msgstr "RECHAZAR"
+#: field:res.company,cookieDeclineButton:0
+msgid "Decline button"
+msgstr "Botón de rechazar"
+
+#. module: website_cookie_notice
+#: field:res.company,cookieDeclineButtonText:0
+msgid "Decline button text"
+msgstr "Texto del botón de rechazar"
 
 #. module: website_cookie_notice
 #: code:addons/website_cookie_notice/models/res_company.py:74
 #, python-format
-msgid "RESET COOKIES FOR THIS WEBSITE"
-msgstr "ELIMINAR COOKIES"
+msgid "Decline cookies"
+msgstr "Rechazar cookies"
 
 #. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:33
+#: help:res.company,cookieOverlayEnabled:0
+msgid "Don't want a discreet toolbar? Fine, set this to true"
+msgstr "¿No quiere una barra de herramientas discreta? Entonces active esto."
+
+#. module: website_cookie_notice
+#: field:res.company,cookieErrorMessage:0
+msgid "Error message"
+msgstr "Mensaje de error"
+
+#. module: website_cookie_notice
+#: help:res.company,cookiePolicyLink:0
+msgid "If applicable, enter the link to your privacy policy here..."
+msgstr "Si aplica, introduzca el enlace a su política de privacidad aquí."
+
+#. module: website_cookie_notice
+#: help:res.company,cookieAnalytics:0
+msgid "Just using a simple analytics package? change this to true"
+msgstr "¿Tan solo usa una página simple de analíticas? Active esto."
+
+#. module: website_cookie_notice
+#: field:res.company,cookieMessage:0
+msgid "Message"
+msgstr "Mensaje"
+
+#. module: website_cookie_notice
+#: field:res.company,cookieOverlayEnabled:0
+msgid "Overlay enabled"
+msgstr "Cubierta activada"
+
+#. module: website_cookie_notice
+#: field:res.company,cookiePolicyLink:0
+msgid "Policy link"
+msgstr "Enlace a su política"
+
+#. module: website_cookie_notice
+#: field:res.company,cookieResetButton:0
+msgid "Reset button"
+msgstr "Botón de reseteo"
+
+#. module: website_cookie_notice
+#: field:res.company,cookieResetButtonText:0
+msgid "Reset button text"
+msgstr "Texto del botón de reseteo"
+
+#. module: website_cookie_notice
+#: code:addons/website_cookie_notice/models/res_company.py:78
 #, python-format
-msgid "We use cookies on this website, you can <a href=\"{{cookiePolicyLink}}\" title=\"read about our cookies\">read about them here</a>. To use the website as intended please..."
-msgstr "Usamos cookies en este sitio web, usted puede saber más sobre ellas en"
-" <a href=\"{{cookiePolicyLink}}\" title=\"lea nuestra política de privacidad\">"
-" nuestra politica de privacidad</a>. Para continuar por favor pulse en ..."
+msgid "Reset cookies for this website"
+msgstr "Resetear cookies para este sitio web"
+
+#. module: website_cookie_notice
+#: code:addons/website_cookie_notice/models/res_company.py:53
+#, python-format
+msgid ""
+"We are sorry, this feature places cookies in your browser and has been "
+"disabled. <br/>To continue using this functionality, please"
+msgstr ""
+"Lo sentimos, esta característica usa cookies en su navegador y ha sido "
+"desactivada. <br/> Para continuar usando esta funcionalidad, por favor"
+
+#. module: website_cookie_notice
+#: code:addons/website_cookie_notice/models/res_company.py:32
+#, python-format
+msgid ""
+"We use cookies on this website, you can <a href=\"{{cookiePolicyLink}}\" "
+"title=\"read about our cookies\">read about them here</a>. To use the "
+"website as intended please..."
+msgstr ""
+"Usamos cookies en este sitio web, usted puede saber más sobre ellas en <a "
+"href=\"{{cookiePolicyLink}}\" title=\"lea nuestra política de privacidad\"> "
+"nuestra politica de privacidad</a>. Para continuar por favor pulse en ..."
 
 #. module: website_cookie_notice
 #: code:addons/website_cookie_notice/models/res_company.py:47
 #, python-format
-msgid "We use cookies, just to track visits to our website, we store no personal details."
-msgstr "Usamos cookies sólo para analizar las visitas a este sitio web,"
-" no almacenamos ningún dato personal."
-
-#. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:52
-#, python-format
-msgid "We're sorry, this feature places cookies in your browser and has been disabled. <br>To continue using this functionality, please"
-msgstr "Lo sentimos, esta funcionalidad almacena cookies en su navegador"
-" y ha sido deshabilitada. <br> Para seguir utilizando esta funcionalidad,"
-" por favor pulse en ..."
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAcceptButton:0
-msgid "cookieAcceptButton"
-msgstr "cookieAcceptButton"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAcceptButtonText:0
-msgid "cookieAcceptButtonText"
-msgstr "cookieAcceptButtonText"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAnalytics:0
-msgid "cookieAnalytics"
-msgstr "cookieAnalytics"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAnalyticsMessage:0
-msgid "cookieAnalyticsMessage"
-msgstr "cookieAnalyticsMessage"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieDeclineButton:0
-msgid "cookieDeclineButton"
-msgstr "cookieDeclineButton"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieDeclineButtonText:0
-msgid "cookieDeclineButtonText"
-msgstr "cookieDeclineButtonText"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieErrorMessage:0
-msgid "cookieErrorMessage"
-msgstr "cookieErrorMessage"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieMessage:0
-msgid "cookieMessage"
-msgstr "cookieMessage"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieOverlayEnabled:0
-msgid "cookieOverlayEnabled"
-msgstr "cookieOverlayEnabled"
-
-#. module: website_cookie_notice
-#: field:res.company,cookiePolicyLink:0
-msgid "cookiePolicyLink"
-msgstr "cookiePolicyLink"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieResetButton:0
-msgid "cookieResetButton"
-msgstr "cookieResetButton"
-
-#. module: website_cookie_notice
-#: field:res.company,cookieResetButtonText:0
-msgid "cookieResetButtonText"
-msgstr "cookieResetButtonText"
+msgid ""
+"We use cookies, just to track visits to our website, we store no personal "
+"details."
+msgstr ""
+"Usamos cookies sólo para analizar las visitas a este sitio web, no "
+"almacenamos ningún dato personal."
 
 #. module: website_cookie_notice
 #: field:res.company,cookieWhatAreTheyLink:0
-msgid "cookieWhatAreTheyLink"
-msgstr "cookieWhatAreTheyLink"
-
-#. module: website_cookie_notice
-#: help:res.company,cookieOverlayEnabled:0
-msgid "don't want a discreet toolbar? Fine, set this to true"
-msgstr "¿No quiere una barra discreta? Entonces, active esta opción"
-
-#. module: website_cookie_notice
-#: help:res.company,cookiePolicyLink:0
-msgid "if applicable, enter the link to your privacy policy here..."
-msgstr "Si aplica, introduce el enlace a la página de Política de Privacidad aquí ..."
-
-#. module: website_cookie_notice
-#: help:res.company,cookieAnalytics:0
-msgid "just using a simple analytics package? change this to true"
-msgstr "¿Está usando sólo cookies para medir las visitas?"
-" Entonces, activa esta opción y se mostrará el mensaje configurado en 'cookieAnalyticsMessage'"
-
+msgid "What are they link"
+msgstr "Enlace de qué son"

--- a/website_cookie_notice/i18n/website_cookie_notice.pot
+++ b/website_cookie_notice/i18n/website_cookie_notice.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-23 19:38+0000\n"
-"PO-Revision-Date: 2015-06-23 19:38+0000\n"
+"POT-Creation-Date: 2015-10-16 14:06+0000\n"
+"PO-Revision-Date: 2015-10-16 14:06+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:67
-#, python-format
-msgid "ACCEPT COOKIES"
+#: field:res.company,cookieAcceptButton:0
+msgid "Accept button"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieAcceptButtonText:0
+msgid "Accept button text"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieAnalytics:0
+msgid "Analytics"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieAnalyticsMessage:0
+msgid "Analytics message"
 msgstr ""
 
 #. module: website_cookie_notice
@@ -32,19 +46,80 @@ msgid "Cookie notice"
 msgstr ""
 
 #. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:70
-#, python-format
-msgid "DECLINE COOKIES"
+#: field:res.company,cookieDeclineButton:0
+msgid "Decline button"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieDeclineButtonText:0
+msgid "Decline button text"
 msgstr ""
 
 #. module: website_cookie_notice
 #: code:addons/website_cookie_notice/models/res_company.py:74
 #, python-format
-msgid "RESET COOKIES FOR THIS WEBSITE"
+msgid "Decline cookies"
 msgstr ""
 
 #. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:33
+#: help:res.company,cookieOverlayEnabled:0
+msgid "Don't want a discreet toolbar? Fine, set this to true"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieErrorMessage:0
+msgid "Error message"
+msgstr ""
+
+#. module: website_cookie_notice
+#: help:res.company,cookiePolicyLink:0
+msgid "If applicable, enter the link to your privacy policy here..."
+msgstr ""
+
+#. module: website_cookie_notice
+#: help:res.company,cookieAnalytics:0
+msgid "Just using a simple analytics package? change this to true"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieMessage:0
+msgid "Message"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieOverlayEnabled:0
+msgid "Overlay enabled"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookiePolicyLink:0
+msgid "Policy link"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieResetButton:0
+msgid "Reset button"
+msgstr ""
+
+#. module: website_cookie_notice
+#: field:res.company,cookieResetButtonText:0
+msgid "Reset button text"
+msgstr ""
+
+#. module: website_cookie_notice
+#: code:addons/website_cookie_notice/models/res_company.py:78
+#, python-format
+msgid "Reset cookies for this website"
+msgstr ""
+
+#. module: website_cookie_notice
+#: code:addons/website_cookie_notice/models/res_company.py:53
+#, python-format
+msgid "We are sorry, this feature places cookies in your browser and has been disabled. <br/>To continue using this functionality, please"
+msgstr ""
+
+#. module: website_cookie_notice
+#: code:addons/website_cookie_notice/models/res_company.py:32
 #, python-format
 msgid "We use cookies on this website, you can <a href=\"{{cookiePolicyLink}}\" title=\"read about our cookies\">read about them here</a>. To use the website as intended please..."
 msgstr ""
@@ -56,88 +131,7 @@ msgid "We use cookies, just to track visits to our website, we store no personal
 msgstr ""
 
 #. module: website_cookie_notice
-#: code:addons/website_cookie_notice/models/res_company.py:52
-#, python-format
-msgid "We're sorry, this feature places cookies in your browser and has been disabled. <br>To continue using this functionality, please"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAcceptButton:0
-msgid "cookieAcceptButton"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAcceptButtonText:0
-msgid "cookieAcceptButtonText"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAnalytics:0
-msgid "cookieAnalytics"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieAnalyticsMessage:0
-msgid "cookieAnalyticsMessage"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieDeclineButton:0
-msgid "cookieDeclineButton"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieDeclineButtonText:0
-msgid "cookieDeclineButtonText"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieErrorMessage:0
-msgid "cookieErrorMessage"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieMessage:0
-msgid "cookieMessage"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieOverlayEnabled:0
-msgid "cookieOverlayEnabled"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookiePolicyLink:0
-msgid "cookiePolicyLink"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieResetButton:0
-msgid "cookieResetButton"
-msgstr ""
-
-#. module: website_cookie_notice
-#: field:res.company,cookieResetButtonText:0
-msgid "cookieResetButtonText"
-msgstr ""
-
-#. module: website_cookie_notice
 #: field:res.company,cookieWhatAreTheyLink:0
-msgid "cookieWhatAreTheyLink"
-msgstr ""
-
-#. module: website_cookie_notice
-#: help:res.company,cookieOverlayEnabled:0
-msgid "don't want a discreet toolbar? Fine, set this to true"
-msgstr ""
-
-#. module: website_cookie_notice
-#: help:res.company,cookiePolicyLink:0
-msgid "if applicable, enter the link to your privacy policy here..."
-msgstr ""
-
-#. module: website_cookie_notice
-#: help:res.company,cookieAnalytics:0
-msgid "just using a simple analytics package? change this to true"
+msgid "What are they link"
 msgstr ""
 

--- a/website_cookie_notice/models/res_company.py
+++ b/website_cookie_notice/models/res_company.py
@@ -19,57 +19,61 @@
 #
 ##############################################################################
 
-from openerp import models, fields
-from openerp.tools.translate import _
+from openerp import _, models, fields
 
 
 class Company(models.Model):
     _inherit = "res.company"
     cookieAnalytics = fields.Boolean(
-        string="cookieAnalytics",
-        help="just using a simple analytics package? change this to true")
+        string="Analytics",
+        help="Just using a simple analytics package? change this to true")
     cookieMessage = fields.Char(
-        string="cookieMessage",
-        default=_('We use cookies on this website, you can '
-                  '<a href="{{cookiePolicyLink}}" title="read about our '
-                  'cookies">read about them here</a>. To use the website as '
-                  'intended please...'),
+        string="Message",
+        default=lambda self: _(
+            'We use cookies on this website, you can '
+            '<a href="{{cookiePolicyLink}}" title="read about our '
+            'cookies">read about them here</a>. To use the website as '
+            'intended please...'),
         translate=True)
     cookiePolicyLink = fields.Char(
-        string="cookiePolicyLink",
-        help="if applicable, enter the link to your privacy policy here...",
+        string="Policy link",
+        help="If applicable, enter the link to your privacy policy here...",
         default='/page/privacy')
     cookieOverlayEnabled = fields.Boolean(
-        string="cookieOverlayEnabled",
-        help="don't want a discreet toolbar? Fine, set this to true")
+        string="Overlay enabled",
+        help="Don't want a discreet toolbar? Fine, set this to true")
     cookieAnalyticsMessage = fields.Char(
-        string="cookieAnalyticsMessage",
-        default=_('We use cookies, just to track visits to our website, we '
-                  'store no personal details.'),
+        string="Analytics message",
+        default=lambda self: _(
+            'We use cookies, just to track visits to our website, we '
+            'store no personal details.'),
         translate=True)
     cookieErrorMessage = fields.Char(
-        string="cookieErrorMessage",
-        default=_("We\'re sorry, this feature places cookies in your browser "
-                  "and has been disabled. <br>To continue using this "
-                  "functionality, please"),
+        string="Error message",
+        default=lambda self: _(
+            "We are sorry, this feature places cookies in your browser "
+            "and has been disabled. <br/>To continue using this "
+            "functionality, please"),
         translate=True)
     cookieDeclineButton = fields.Boolean(
-        string="cookieDeclineButton")
+        string="Decline button")
     cookieAcceptButton = fields.Boolean(
-        string="cookieAcceptButton",
+        string="Accept button",
         default=True)
     cookieResetButton = fields.Boolean(
-        string="cookieResetButton")
+        string="Reset button")
     cookieWhatAreTheyLink = fields.Char(
-        string="cookieWhatAreTheyLink",
+        string="What are they link",
         default="http://www.allaboutcookies.org/")
     cookieAcceptButtonText = fields.Char(
-        string="cookieAcceptButtonText", default=_("ACCEPT COOKIES"),
+        string="Accept button text",
+        default="Accept cookies",
         translate=True)
     cookieDeclineButtonText = fields.Char(
-        string="cookieDeclineButtonText", default=_("DECLINE COOKIES"),
+        string="Decline button text",
+        default=lambda self: _("Decline cookies"),
         translate=True)
     cookieResetButtonText = fields.Char(
-        string="cookieResetButtonText",
-        default=_("RESET COOKIES FOR THIS WEBSITE"),
+        string="Reset button text",
+        default=lambda self: _("Reset cookies for this website"),
         translate=True)


### PR DESCRIPTION
Newly created companies did not have the messages in the right language.

Existing installations probably will have to change this by hand.

Also simplified some redundant code from the controller.

cc @rafaelbn 
