### PR TITLE
[8.0][IMP][website_container_fluid][website_sale_collapse_categories] Don't ignore maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,3 @@ docs/_build/
 # Backup files
 *~
 *.swp
-
-# Debug maps
-*.css.map

--- a/website_container_fluid/static/src/css/styles.css.map
+++ b/website_container_fluid/static/src/css/styles.css.map
@@ -1,0 +1,7 @@
+{
+"version": 3,
+"mappings": "AAEA,2BAA2B;EACvB,KAAK,EAAE,IAAI",
+"sources": ["styles.sass"],
+"names": [],
+"file": "styles.css"
+}

--- a/website_sale_collapse_categories/static/src/css/website_sale.css.map
+++ b/website_sale_collapse_categories/static/src/css/website_sale.css.map
@@ -1,0 +1,7 @@
+{
+"version": 3,
+"mappings": "AAEQ,8BAAC;EACG,OAAO,EAAE,YAAY;EACrB,KAAK,EAAE,GAAG;EACV,YAAY,EAAE,GAAG;AAErB,iCAAI;EACA,MAAM,EAAE,OAAO",
+"sources": ["website_sale.sass"],
+"names": [],
+"file": "website_sale.css"
+}


### PR DESCRIPTION
I'm reverting something I did in the past. Debug maps are quite useful because modern browsers allow you to debug directly the less/sass equivalent of the final CSS file you use if you add `?debug` to your URL.
