### PR TITLE
[8.0][website_event_register_free_with_sale] Ensure event_id is int.

### DIFF
--- a/website_event_register_free_with_sale/controllers/website_sale.py
+++ b/website_event_register_free_with_sale/controllers/website_sale.py
@@ -66,7 +66,7 @@ class WebsiteSale(website_sale):
                 return request.website.render("website_sale.checkout", values)
             post['tickets'] = request.session['free_tickets']
             event = request.env['event.event'].browse(
-                request.session['event_id'])
+                int(request.session['event_id']))
             if (http.request.env.ref('base.public_user') !=
                     http.request.env.user):
                 partner = http.request.env.user.partner_id


### PR DESCRIPTION
Wrong type was raising the error shown in https://github.com/OCA/event/pull/19.
