### PR TITLE
[FIX] Allowing all users to read filter

### DIFF
--- a/website_crm_quick_answer/data/automation.xml
+++ b/website_crm_quick_answer/data/automation.xml
@@ -4,6 +4,7 @@
 
 <record id="website_form_leads_filter" model="ir.filters">
     <field name="name">Coming from the website contact form</field>
+    <field name="user_id" eval="False"/>
     <field name="model_id">crm.lead</field>
     <field name="domain"
            eval="[('section_id', '=', ref('website.salesteam_website_sales')),


### PR DESCRIPTION
When creating filter to be associated with email action, then it is created with `user_id = Administrator` and then other users can not read it.

When a user creates a lead or an opportunity then action is evaluated and filter read, then an Access Error is raised because user can not read Administrator filters.

If `user_id = False`, then all users can read it and no Access Error will appear.
