### PR TITLE
[FIX][8.0][website_signup_legal_page_required] Users were not able to sign up when they recieved a token.

### DIFF
--- a/website_signup_legal_page_required/views/pages.xml
+++ b/website_signup_legal_page_required/views/pages.xml
@@ -8,8 +8,7 @@
           active="True"
           customize_show="True">
     <xpath expr="./div[last()]" position="after">
-        <div t-if="not only_passwords"
-             class="form-group field-accepted_legal_terms">
+        <div class="form-group field-accepted_legal_terms">
             <label for="accepted_legal_terms" class="control-label">
                 <input type="checkbox"
                        name="accepted_legal_terms"


### PR DESCRIPTION
It happened because the required check box was not displayed.

Hot patch for https://github.com/OCA/website/pull/111#issuecomment-160674487.
