### PR TITLE
[8.0][website_slides][FIX] Use compiled CSS and fix fullscreen PDF proportion

### DIFF
--- a/website_slides/static/lib/pdfslidesviewer/PDFSlidesViewer.js
+++ b/website_slides/static/lib/pdfslidesviewer/PDFSlidesViewer.js
@@ -145,8 +145,14 @@ var PDFSlidesViewer = (function(){
         return this.queueRenderPage(this.pdf_page_total);
     }
 
+    PDFSlidesViewer.prototype.toggleFullScreenFooter = function(){
+        if(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement) {
+            $('div#PDFViewer > div.navbar-fixed-bottom').toggleClass('oe_show_footer');
+        }
+    }
+
     PDFSlidesViewer.prototype.toggleFullScreen = function(){
-        var el = this.canvas;
+        var el = this.canvas.parentNode;
 
         var isFullscreenAvailable = document.fullscreenEnabled || document.mozFullScreenEnabled || document.webkitFullscreenEnabled || document.msFullscreenEnabled || false;
         if(isFullscreenAvailable){ // Full screen supported

--- a/website_slides/static/src/css/website_slides.css
+++ b/website_slides/static/src/css/website_slides.css
@@ -1,0 +1,148 @@
+.oe_slides_panel_footer {
+  background-color: #f8f8f8;
+}
+.oe_slides_panel_footer .fa,
+.oe_slide_js_embed_option_link {
+  color: #428bca;
+  cursor: pointer;
+}
+.oe_slide_embed_option {
+  position: absolute;
+  padding: 30px 30px 30px 30px;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: #ffffff;
+  opacity: 1;
+  display: none;
+  overflow-y: auto !important;
+}
+.oe_slide_embed_wrapper {
+  position: relative;
+}
+section.oe_slides_promote_box {
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #dddddd;
+  border-top: 1px solid #dddddd;
+}
+img.oe_slides_channel_thumbnail {
+  height: 250px;
+  width: 100%;
+}
+img.oe_slides_opacity {
+  opacity: .5;
+}
+img.oe_slides_promote_image {
+  max-height: 300px;
+  width: 100%;
+  overflow: hidden;
+  display: block;
+}
+.oe_slides_box_shadow {
+  box-shadow: 0 0 5px #CCC;
+}
+.oe_slides_apart_small {
+  height: 60px;
+  width: 90px;
+}
+.oe_slides_statistics_title {
+  border-bottom: 1px solid #dddddd;
+  padding-bottom: 5px;
+}
+.oe_slides_transcript {
+  overflow-y: auto;
+  max-height: 500px;
+}
+.oe_slides_bottom_border {
+  border-bottom: 1px solid #dddddd;
+}
+.oe_slide_js_like,
+.oe_slide_js_unlike {
+  cursor: pointer;
+  color: #428bca;
+}
+.oe_slides_thumbnail_container {
+  height: 300px;
+}
+.oe_slides_grid_thumbnail {
+  height: 200px;
+  width: 100%;
+  overflow: hidden;
+}
+.oe_slides_ellipsis {
+  white-space: nowrap;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.oe_slides_suggestion_caption {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: rgba(10, 10, 10, 0.75);
+  width: 100%;
+  height: 100%;
+  display: none;
+  text-align: center;
+  color: #fff !important;
+  z-index: 2;
+}
+.oe_slides_suggestion_media {
+  margin-top: 10px;
+  position: relative;
+}
+.oe_slides_suggestion_media img {
+  height: 33%;
+  width: 100%;
+  overflow: hidden;
+}
+.oe_slides_loader {
+  position: relative;
+  width: 100%;
+  /* for IE 6 */
+}
+.oe_slides_loader h4 {
+  position: absolute;
+  bottom: 20px;
+  left: 0;
+  width: 35%;
+  color: white;
+  background: #000000;
+  /* fallback color */
+  background: rgba(0, 0, 0, 0.7);
+  padding: 10px;
+}
+.oe_slides_panel {
+  padding-bottom: 50px;
+  height: 100%;
+  margin-bottom: 0px;
+}
+.oe_slides_share_bar {
+  padding: 10px 0;
+}
+.embed-responsive {
+  position: relative;
+  display: block;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+}
+.embed-responsive .embed-responsive-item,
+.embed-responsive iframe,
+.embed-responsive embed,
+.embed-responsive object {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+.embed-responsive.embed-responsive-16by9 {
+  padding-bottom: 56.25%;
+}
+.embed-responsive.embed-responsive-4by3 {
+  padding-bottom: 75%;
+}

--- a/website_slides/views/website_slides.xml
+++ b/website_slides/views/website_slides.xml
@@ -17,7 +17,10 @@
 
         <link rel="stylesheet" href="/web/static/lib/select2/select2.css"/>
         <link rel="stylesheet" href="/website/static/lib/select2-bootstrap-css/select2-bootstrap.css"/>
-        <link type="text/less" href="/website_slides/static/src/less/website_slides.less" rel="stylesheet" t-ignore="true"/>
+        <link type="text/css"
+              href="/website_slides/static/src/css/website_slides.css"
+              rel="stylesheet"
+              t-ignore="true"/>
         <!-- Js widgets, ... order loading files is IMPORTANT -->
         <script type="text/javascript" src="/web/static/lib/select2/select2.js"></script>
         <script type="text/javascript" src="/website_slides/static/src/js/slides.js"/>

--- a/website_slides/views/website_slides_embed.xml
+++ b/website_slides/views/website_slides_embed.xml
@@ -6,7 +6,10 @@
         <template id="website_slides.slide_embed_assets" name="Website slides embed assets">
             <link rel='stylesheet' href='/web/static/lib/fontawesome/css/font-awesome.css'/>
             <link rel='stylesheet' href='/web/static/lib/bootstrap/css/bootstrap.css'/>
-            <link type="text/less" href="/website_slides/static/src/less/website_slides.less" rel="stylesheet" t-ignore="true"/>
+            <link type="text/css"
+                  href="/website_slides/static/src/css/website_slides.css"
+                  rel="stylesheet"
+                  t-ignore="true"/>
 
             <script type="text/javascript" src="/web/static/lib/jquery/jquery.js"></script>
             <script type="text/javascript" src="/web/static/lib/bootstrap/js/bootstrap.js"></script>


### PR DESCRIPTION
Odoo 9.0 autocompiles `.less` files, but v8 does not, so we have to serve the precompiled CSS.

Also there was a bug with fullscreen PDF files, which were showing up like this:

![captura de pantalla de 2015-12-23 11-26-44](https://cloud.githubusercontent.com/assets/973709/11974922/0147d470-a969-11e5-811e-63bbcdfedf72.png)

With the backported fix, they look like this:

![captura de pantalla de 2015-12-23 11-27-14](https://cloud.githubusercontent.com/assets/973709/11974924/067688ce-a969-11e5-83bc-6c2804383bbc.png)
