### PR TITLE
[FIX][8.0] website_cookie_notice: added cookiecuttr.css

### DIFF
--- a/website_cookie_notice/static/src/css/cookiecuttr.css
+++ b/website_cookie_notice/static/src/css/cookiecuttr.css
@@ -1,0 +1,19 @@
+/* To be used with cookieCuttr by Chris Wharton (http://cookiecuttr.com) */
+
+.cc-cookies { width: 100%; left: 0; top: 0; padding: 0.5em 5%; background: #565656; background: rgba(86,86,86,0.95); color: #fff; font-size: 13px; font-weight: 700; text-shadow: 0 -1px 0 rgba(0,0,0,0.35); z-index: 99999; text-align: center; color: #fff; }
+.cc-cookies a, .cc-cookies a:hover { color: #fff; text-decoration: underline; }
+.cc-cookies a:hover { text-decoration: none; }
+.cc-overlay { height: 100%; padding-top: 25%; }
+.cc-cookies-error { float: left; width: 100%; text-align: center; margin: 1em 0 2em 0; background: #fff; padding: 2em 5%; border: 1px solid #ccc; font-size: 18px; color: #333; }
+.cc-cookies a.cc-cookie-accept, .cc-cookies-error a.cc-cookie-accept, .cc-cookies a.cc-cookie-decline, .cc-cookies-error a.cc-cookie-decline, .cc-cookies a.cc-cookie-reset { display: inline-block; color: #fff; text-decoration: none; background: #7DAF3B; padding: 0.5em 0.75em; border-radius: 3px; box-shadow: 0 0 2px rgba(0,0,0,0.25); text-shadow: 0 -1px 0 rgba(0,0,0,0.35); -o-transition: background 0.5s ease-in; -webkit-transition: background 0.25s ease-in; -moz-transition: background 0.25s ease-in; }
+.cc-cookies a.cc-cookie-decline, .cc-cookies-error a.cc-cookie-decline { background: #af3b3b; margin-left: 0.5em; }
+.cc-cookies a.cc-cookie-reset { background: #f15b00; }
+.cc-cookies a:hover.cc-cookie-accept, .cc-cookies-error a:hover.cc-cookie-accept, .cc-cookies a:hover.cc-cookie-decline, .cc-cookies-error a:hover.cc-cookie-decline, .cc-cookies a:hover.cc-cookie-reset  { background: #000; -o-transition: background 0.5s ease-in; -webkit-transition: background 0.25s ease-in; -moz-transition: background 0.25s ease-in; }
+.cc-cookies-error a.cc-cookie-accept, .cc-cookies-error a.cc-cookie-decline { display: block; margin-top: 1em; }
+.cc-cookies.cc-discreet { width: auto; padding: 0.5em 1em; left: auto; top: auto; }
+.cc-cookies.cc-discreet a.cc-cookie-reset { background: none; text-shadow: none; padding: 0; text-decoration: underline; }
+.cc-cookies.cc-discreet a:hover.cc-cookie-reset { text-decoration: none; }
+
+@media screen and (max-width: 768px) {
+.cc-cookies a.cc-cookie-accept, .cc-cookies a.cc-cookie-decline, .cc-cookies a.cc-cookie-reset { display: block; margin: 1em 0; }
+}

--- a/website_cookie_notice/views/website.xml
+++ b/website_cookie_notice/views/website.xml
@@ -4,12 +4,10 @@
 
 <template id="assets_frontend" inherit_id="website.assets_frontend">
     <xpath expr=".">
-        <script t-if="request and
-                      not request.httpsession.get('accepted_cookies')"
-                type="text/javascript"
-                src="/website_cookie_notice/static/src/js/accept_cookies.js">
-        </script>
-        <link rel="stylesheet" href="/website_cookie_notice/static/src/css/cookiecuttr.css"/>
+    	<t t-if="request and not request.httpsession.get('accepted_cookies')">
+    		<link rel="stylesheet" href="/website_cookie_notice/static/src/css/cookiecuttr.css" />
+        	<script type="text/javascript" src="/website_cookie_notice/static/src/js/accept_cookies.js"></script>
+        </t>
     </xpath>
 </template>
 

--- a/website_cookie_notice/views/website.xml
+++ b/website_cookie_notice/views/website.xml
@@ -9,6 +9,7 @@
                 type="text/javascript"
                 src="/website_cookie_notice/static/src/js/accept_cookies.js">
         </script>
+        <link rel="stylesheet" href="/website_cookie_notice/static/src/css/cookiecuttr.css"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
This PR fix #135 

Adds the cookiecuttr.css and includes the necessary line in assets_frontend
