### PR TITLE
[Fix] Use the URL field of the slide

### DIFF
--- a/website_slides/views/website_slides_embed.xml
+++ b/website_slides/views/website_slides_embed.xml
@@ -61,7 +61,7 @@
                     <!--  PDF Viewer Body : contains the canvas, the loader, or the image-->
                     <div id="PDFSlideViewer" style="position:relative;"
                             t-attf-data-slideid="#{slide.id}"
-                            t-attf-data-slideurl="/slides/slide/#{slide.id}/pdf_content"
+                            t-attf-data-slideurl="#{slide.website_url}/pdf_content"
                             t-attf-data-downloadable="#{slide.download_security}"
                             t-att-data-defaultpage="page">
                         <t t-if="is_embedded">


### PR DESCRIPTION
When you are over HTTPS and you want to load a slide. Chrome stops it because it tries to load the slide without HTTP. By using the field website_url coming from the slide model, if the URL of the slide is with HTTPS, you'll not have this error anymore.

![image](https://cloud.githubusercontent.com/assets/7678583/12239096/61a29dfa-b887-11e5-86d9-b2591d3811c2.png)
