### PR TITLE
[FIX] Spanish translation

### DIFF
--- a/website_cookie_notice/i18n/es.po
+++ b/website_cookie_notice/i18n/es.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* website_cookie_notice
+#	* website_cookie_notice
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-27 16:28+0100\n"
-"PO-Revision-Date: 2015-10-27 16:29+0100\n"
+"POT-Creation-Date: 2016-01-28 15:35+0000\n"
+"PO-Revision-Date: 2016-01-28 15:35+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -18,22 +18,20 @@ msgstr ""
 "X-Generator: Poedit 1.8.5\n"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
-msgid ""
-".\n"
-"                        To disable them, configure your browser properly.\n"
-"                        If you keep using this website, you are accepting "
-"those."
+#: view:website:website_cookie_notice.message
+msgid ".\n"
+"                    To disable them, configure your browser properly.\n"
+"                    If you keep using this website, you are accepting those."
 msgstr ""
 ". Para desactivarlas, configure adecuadamente su navegador. Si continúa "
 "usando este sitio web, está aceptándolas."
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid "We use cookies in this website. Read about them in our"
 msgstr "Usamos cookies en este sitio web. Lea más acerca de ellas en nuestra"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid "privacy policy"
 msgstr "política de privacidad"


### PR DESCRIPTION
Odoo can not translate cookie banner to Spanish.
Reviewing Transifex all terms are OK, but .po generated is not good enought.

With this PR changes, translation runs well.
