### PR TITLE
[8.0][IMP][website_logo] Select no logo in a website

### DIFF
--- a/website_logo/controllers/main.py
+++ b/website_logo/controllers/main.py
@@ -75,8 +75,6 @@ class Website(http.Controller):
                     image, mtime = self._image_logo_get(cr, domain)
                     if not image:
                         image, mtime = self._image_logo_get(cr, 'localhost')
-                    if not image:
-                        image, mtime = self._image_logo_get(cr)
                     if image:
                         response = http.send_file(
                             image, filename=imgname, mtime=mtime)


### PR DESCRIPTION
Allow to no show logo in a website, by not selecting logo in website settings.
This is useful when website_multi addon is installed.
