### PR TITLE
[8.0][FIX][website_slides] Remove host from URL, making all paths relative.

### DIFF
--- a/website_slides/views/website_slides.xml
+++ b/website_slides/views/website_slides.xml
@@ -395,7 +395,7 @@
             <meta property="og:title" t-att-content="slide.name" />
             <meta property="og:type" content="website" />
             <meta property="og:url" t-att-content="slide.website_url" />
-            <meta property="og:image" t-attf-content="#{request.httprequest.host_url}/website/image/slide.slide/#{slide.id}/image_thumb"/>
+            <meta property="og:image" t-attf-content="/website/image/slide.slide/#{slide.id}/image_thumb"/>
             <meta property="og:description" t-att-content="slide.description" />
         </t>
     </t>


### PR DESCRIPTION
This way, if your HTTPS site is behind a proxy, you will not get HTTP urls.
