### PR TITLE
[8.0][FIX][website_cookie_notice] Cookie message translation (2)

### DIFF
--- a/website_cookie_notice/i18n/el_GR.po
+++ b/website_cookie_notice/i18n/el_GR.po
@@ -19,16 +19,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid ". To disable them, configure your browser properly. If you keep using this website, you are accepting those."
 msgstr ". Για να απενεργοποιήσετε τα cookies, ρυθμίσετε κατάλληλα τον browser σας. Εάν συνεχίσετε τη χρήση αυτού του ιστότοπου, αποδέχεστε αυτούς τους όρους."
 
 #. module: website_cookie_notice
-#: view:website:website.layout
-msgid "We use cookies in this website. Read about them in our "
-msgstr "Χρησιμοποιούμε cookies σε αυτόν τον ιστότοπο. Διαβάστε σχετικά την "
+#: view:website:website_cookie_notice.message
+msgid "We use cookies in this website. Read about them in our"
+msgstr "Χρησιμοποιούμε cookies σε αυτόν τον ιστότοπο. Διαβάστε σχετικά την"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid "privacy policy"
 msgstr "πολιτική απορρήτου"

--- a/website_cookie_notice/i18n/en.po
+++ b/website_cookie_notice/i18n/en.po
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid ". To disable them, configure your browser properly. If you keep using this website, you are accepting those."
 msgstr ". To disable them, configure your browser properly. If you keep using this website, you are accepting those."
 
 #. module: website_cookie_notice
-#: view:website:website.layout
-msgid "We use cookies in this website. Read about them in our "
-msgstr "We use cookies in this website. Read about them in our "
+#: view:website:website_cookie_notice.message
+msgid "We use cookies in this website. Read about them in our"
+msgstr "We use cookies in this website. Read about them in our"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid "privacy policy"
 msgstr "privacy policy"

--- a/website_cookie_notice/i18n/es.po
+++ b/website_cookie_notice/i18n/es.po
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid ". To disable them, configure your browser properly. If you keep using this website, you are accepting those."
 msgstr ". Para desactivarlas, configure adecuadamente su navegador. Si continúa usando este sitio web, está aceptándolas."
 
 #. module: website_cookie_notice
-#: view:website:website.layout
-msgid "We use cookies in this website. Read about them in our "
-msgstr "Usamos cookies en este sitio web. Lea más acerca de ellas en nuestra "
+#: view:website:website_cookie_notice.message
+msgid "We use cookies in this website. Read about them in our"
+msgstr "Usamos cookies en este sitio web. Lea más acerca de ellas en nuestra"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid "privacy policy"
 msgstr "política de privacidad"

--- a/website_cookie_notice/i18n/ru.po
+++ b/website_cookie_notice/i18n/ru.po
@@ -19,16 +19,16 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid ". To disable them, configure your browser properly. If you keep using this website, you are accepting those."
 msgstr ". Чтобы отключить их, настройте свой браузер. Если Вы продолжите просматривать данный сайт, Вы автоматически соглашаетесь с этим."
 
 #. module: website_cookie_notice
-#: view:website:website.layout
-msgid "We use cookies in this website. Read about them in our "
-msgstr "Мы используем куки на этом сайте. Узнайте о них на нашем "
+#: view:website:website_cookie_notice.message
+msgid "We use cookies in this website. Read about them in our"
+msgstr "Мы используем куки на этом сайте. Узнайте о них на нашем"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid "privacy policy"
 msgstr "политика конфиденциальности"

--- a/website_cookie_notice/i18n/sl.po
+++ b/website_cookie_notice/i18n/sl.po
@@ -19,16 +19,16 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid ". To disable them, configure your browser properly. If you keep using this website, you are accepting those."
 msgstr ". Da bi jih onemogočili, temu primerno nastavite svoj brskalnik. Če boste nadaljevali z uporabo te spletne strani, smatramo, da jih sprejemate."
 
 #. module: website_cookie_notice
-#: view:website:website.layout
-msgid "We use cookies in this website. Read about them in our "
-msgstr "Naša spletna stran uporablja piškotke. Več o njih preberite v naših "
+#: view:website:website_cookie_notice.message
+msgid "We use cookies in this website. Read about them in our"
+msgstr "Naša spletna stran uporablja piškotke. Več o njih preberite v naših"
 
 #. module: website_cookie_notice
-#: view:website:website.layout
+#: view:website:website_cookie_notice.message
 msgid "privacy policy"
 msgstr "pravilih o zasebnosti"

--- a/website_cookie_notice/views/website.xml
+++ b/website_cookie_notice/views/website.xml
@@ -21,10 +21,10 @@
                 <div class="col-xs-2 text-center">
                     <a class="btn btn-primary"
                         href="/website_cookie_notice/ok">OK</a>
-                    </div>
                 </div>
             </div>
         </div>
+    </div>
 </template>
 
 <template id="assets_frontend" inherit_id="website.assets_frontend">


### PR DESCRIPTION
This PR is related with #169 
The problem was not only spaces, also translation definition of res_id was not correct:

```
#: view:website:website.layout
```

This must be

```
#: view:website:website_cookie_notice.message
```

It seems that this problem was caused by @oca-transbot here https://github.com/Antiun/website/commit/550d148f19aeb689789e7fabc94bdd9ba9049931#diff-b4e6e0424c922617ebb787e6c6464dd3

We should review how Transifex generates .po files
