### PR TITLE
[FIX] website_portal_sale: Order list indicates "Invoiced" state when…

### DIFF
--- a/website_portal_sale/templates/website_portal_sale.xml
+++ b/website_portal_sale/templates/website_portal_sale.xml
@@ -70,7 +70,7 @@
                             <td><span t-field="order.date_confirm"/></td>
                             <td>
                                 <t t-if="order.state == 'progress'">
-                                    <span class="label label-info"><i class="fa fa-fw fa-clock-o"/> Invoiced</span>
+                                    <span class="label label-info"><i class="fa fa-fw fa-clock-o"/> In preparation</span>
                                 </t>
                                 <t t-if="order.state in ['shipping_except','invoice_except']">
                                     <span class="label label-danger"><i class="fa fa-fw fa-warning"/> Problem</span>


### PR DESCRIPTION
… order is "In progress" and not necessarily invoiced yet.
