### PR TITLE
Upgrade website_legal_page to 9.0

### DIFF
--- a/website_legal_page/README.rst
+++ b/website_legal_page/README.rst
@@ -80,6 +80,7 @@ Contributors
 * Rafael Blasco <rafabn@antiun.com>
 * Antonio Espinosa <antonioea@antiun.com>
 * Igor Pastor <igorpg@antiun.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/website_legal_page/__init__.py
+++ b/website_legal_page/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
-# Python source code encoding : https://www.python.org/dev/peps/pep-0263/
-##############################################################################
+# © 2015 Antiun Ingeniería S.L. (http://www.antiun.com)
+# © 2015 Antonio Espinosa <antonioea@antiun.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/website_legal_page/__openerp__.py
+++ b/website_legal_page/__openerp__.py
@@ -28,6 +28,7 @@
         'website',
     ],
     'data': [
+        'views/reusable_templates.xml',
         'views/website_legal.xml',
         'views/website_privacy.xml',
         'views/website_terms.xml',

--- a/website_legal_page/__openerp__.py
+++ b/website_legal_page/__openerp__.py
@@ -1,29 +1,13 @@
 # -*- coding: utf-8 -*-
-# Python source code encoding : https://www.python.org/dev/peps/pep-0263/
-##############################################################################
-#
-#    OpenERP, Odoo Source Management Solution
-#    Copyright (c) 2015 Antiun Ingeniería S.L. (http://www.antiun.com)
-#                       Antonio Espinosa <antonioea@antiun.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2015 Antiun Ingeniería S.L. (http://www.antiun.com)
+# © 2015 Antonio Espinosa <antonioea@antiun.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 {
-    'name': "Website legal page",
+    'name': "Website Legal Page",
+    'description': 'Add legal information, such as privacy policy',
     'category': 'Website',
-    'version': '8.0.1.0.0',
+    'version': '9.0.1.0.0',
     'depends': [
         'website',
     ],
@@ -34,10 +18,9 @@
         'views/website_terms.xml',
     ],
     'author': 'Antiun Ingeniería S.L., '
+              'LasLabs Inc, '
               'Odoo Community Association (OCA)',
     'website': 'http://www.antiun.com',
     'license': 'AGPL-3',
-    'demo': [],
-    'test': [],
-    'installable': False,
+    'installable': True,
 }

--- a/website_legal_page/i18n/ca.po
+++ b/website_legal_page/i18n/ca.po
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * website_legal_page
+# 
+# Translators:
+# Carles Antolí <carlesantoli@hotmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: website (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 18:42+0000\n"
+"PO-Revision-Date: 2016-03-15 09:39+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: Catalan (http://www.transifex.com/oca/OCA-website-8-0/language/ca/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ca\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", and the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Legal advice"
+msgstr "Avís legal"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Privacy policy"
+msgstr "Política de privacitat"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Terms of use"
+msgstr "Condicions d'ús"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "legal advice"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "of this website."
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "privacy policy"
+msgstr "Política privacitat"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "terms of use"
+msgstr ""

--- a/website_legal_page/i18n/de.po
+++ b/website_legal_page/i18n/de.po
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * website_legal_page
+# 
+# Translators:
+# Rudolf Schnapka <rs@techno-flex.de>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: website (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 18:42+0000\n"
+"PO-Revision-Date: 2016-03-15 09:39+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: German (http://www.transifex.com/oca/OCA-website-8-0/language/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", and the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Legal advice"
+msgstr "Rechtlicher Hinweis"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Privacy policy"
+msgstr "Datenschutzerklärung"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Terms of use"
+msgstr "Nutzungsbedingungen"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "legal advice"
+msgstr "Nutzungshinweise"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "of this website."
+msgstr "der Webseite."
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "privacy policy"
+msgstr "Datenschutzbestimmungen"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "terms of use"
+msgstr "Nutzungsbedingungen"

--- a/website_legal_page/i18n/el_GR.po
+++ b/website_legal_page/i18n/el_GR.po
@@ -1,0 +1,63 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * website_legal_page
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: website (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 18:42+0000\n"
+"PO-Revision-Date: 2016-03-15 09:39+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: Greek (Greece) (http://www.transifex.com/oca/OCA-website-8-0/language/el_GR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: el_GR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", and the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Legal advice"
+msgstr "Νομική συμβουλή"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Privacy policy"
+msgstr "Πολιτική απορρήτου"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Terms of use"
+msgstr "Όροι χρήσης"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "legal advice"
+msgstr "νομική συμβουλή"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "of this website."
+msgstr "σε αυτόν τον ιστότοπο."
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "privacy policy"
+msgstr "πολιτική απορρήτου"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "terms of use"
+msgstr "όροι χρήσης"

--- a/website_legal_page/i18n/it.po
+++ b/website_legal_page/i18n/it.po
@@ -1,0 +1,65 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * website_legal_page
+# 
+# Translators:
+# Paolo Valier, 2016
+# Paolo Valier, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: website (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 18:42+0000\n"
+"PO-Revision-Date: 2016-03-19 09:30+0000\n"
+"Last-Translator: Paolo Valier\n"
+"Language-Team: Italian (http://www.transifex.com/oca/OCA-website-8-0/language/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", and the"
+msgstr ", e le"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", the"
+msgstr ", l'"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Legal advice"
+msgstr "Informazioni legali"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Privacy policy"
+msgstr "Informativa sulla Privacy"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Terms of use"
+msgstr "Condizioni d'uso"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "legal advice"
+msgstr "informazioni legali"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "of this website."
+msgstr "di questo sito."
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "privacy policy"
+msgstr "informativa sulla privacy"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "terms of use"
+msgstr "condizioni d'uso"

--- a/website_legal_page/i18n/pt_BR.po
+++ b/website_legal_page/i18n/pt_BR.po
@@ -1,0 +1,65 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * website_legal_page
+# 
+# Translators:
+# danimaribeiro <danimaribeiro@gmail.com>, 2016
+# danimaribeiro <danimaribeiro@gmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: website (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 18:42+0000\n"
+"PO-Revision-Date: 2016-03-15 09:39+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/OCA-website-8-0/language/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", and the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Legal advice"
+msgstr "Aviso legal"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Privacy policy"
+msgstr "Política de privacidade"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Terms of use"
+msgstr "Termos de uso"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "legal advice"
+msgstr "aviso legal"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "of this website."
+msgstr "deste site"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "privacy policy"
+msgstr "política de privacidade"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "terms of use"
+msgstr "Termos de uso"

--- a/website_legal_page/i18n/ru.po
+++ b/website_legal_page/i18n/ru.po
@@ -1,0 +1,63 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * website_legal_page
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: website (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 18:42+0000\n"
+"PO-Revision-Date: 2015-09-25 08:28+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Russian (http://www.transifex.com/oca/OCA-website-8-0/language/ru/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ru\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", and the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", the"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Legal advice"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Privacy policy"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Terms of use"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "legal advice"
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "of this website."
+msgstr ""
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "privacy policy"
+msgstr "политика конфиденциальности"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "terms of use"
+msgstr ""

--- a/website_legal_page/i18n/sl.po
+++ b/website_legal_page/i18n/sl.po
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * website_legal_page
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015-2016
+msgid ""
+msgstr ""
+"Project-Id-Version: website (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 18:42+0000\n"
+"PO-Revision-Date: 2016-03-16 05:29+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/OCA-website-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", and the"
+msgstr ", in"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid ", the"
+msgstr ", "
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Legal advice"
+msgstr "Pravno obvestilo"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Privacy policy"
+msgstr "Pravila o zasebnosti"
+
+#. module: website_legal_page
+#: view:website:website.layout
+msgid "Terms of use"
+msgstr "Pogoji uporabe"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "legal advice"
+msgstr "pravno obvestilo"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "of this website."
+msgstr "te spletne strani."
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "privacy policy"
+msgstr "pravilih o zasebnosti"
+
+#. module: website_legal_page
+#: view:website:website_legal_page.acceptance_full
+msgid "terms of use"
+msgstr "pogoje uporabe"

--- a/website_legal_page/views/reusable_templates.xml
+++ b/website_legal_page/views/reusable_templates.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
+<odoo>
 
 <!-- Base templates for submodules -->
 <template id="acceptance_full">
@@ -9,5 +8,4 @@
     <a href="/page/terms">terms of use</a> of this website.
 </template>
 
-</data>
-</openerp>
+</odoo>

--- a/website_legal_page/views/reusable_templates.xml
+++ b/website_legal_page/views/reusable_templates.xml
@@ -3,7 +3,7 @@
 <data>
 
 <!-- Base templates for submodules -->
-<template id="acceptance_full" page="False">
+<template id="acceptance_full">
     I accept the <a href="/page/legal">legal advice</a>, the
     <a href="/page/privacy">privacy policy</a>, and the
     <a href="/page/terms">terms of use</a> of this website.

--- a/website_legal_page/views/reusable_templates.xml
+++ b/website_legal_page/views/reusable_templates.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+<!-- Base templates for submodules -->
+<template id="acceptance_full" page="False">
+    I accept the <a href="/page/legal">legal advice</a>, the
+    <a href="/page/privacy">privacy policy</a>, and the
+    <a href="/page/terms">terms of use</a> of this website.
+</template>
+
+</data>
+</openerp>

--- a/website_legal_page/views/website_legal.xml
+++ b/website_legal_page/views/website_legal.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
+<odoo>
 
 <!-- Add legal advice after copyright and company name -->
 <template id="legal_advice_link"
@@ -85,5 +84,4 @@
   </t>
 </template>
 
-</data>
-</openerp>
+</odoo>

--- a/website_legal_page/views/website_privacy.xml
+++ b/website_legal_page/views/website_privacy.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
+<odoo>
 
 <!-- Add privacy policy after copyright and company name -->
 <template id="privacy_policy_link"
@@ -206,5 +205,4 @@
   </t>
 </template>
 
-</data>
-</openerp>
+</odoo>

--- a/website_legal_page/views/website_terms.xml
+++ b/website_legal_page/views/website_terms.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
+<odoo>
 
 <!-- Add terms of use after copyright and company name -->
 <template id="terms_of_use_link"
@@ -211,5 +210,4 @@
   </t>
 </template>
 
-</data>
-</openerp>
+</odoo>


### PR DESCRIPTION
I noticed a massive amount of changes on `website_cookie_notice` in the 8.0 branch while bringing forward to 9.0 for #193. This module is now a dependency for it, so I am upgrading it to 9.0 as well (after cherry picking the 8.0 changes)
