### PR TITLE
[ADD][9.0] Create new module website_field_autocomplete

### DIFF
--- a/website_field_autocomplete/README.rst
+++ b/website_field_autocomplete/README.rst
@@ -23,6 +23,7 @@ To use this module, you need to add an input field with the
            class="js_website_autocomplete"
            data-query-field="name"
            data-display-field="name"
+           data-value-field="id"
            data-limit="10"
            data-domain='[["website_published", "=", true]]'
            data-model="product.template"
@@ -30,19 +31,21 @@ To use this module, you need to add an input field with the
 
 Following is a breakdown of the available attributes & their defaults:
 
-+--------------------+---------------------------------------------+-------------+----------+
-|  Attribute         |  Description                                |  Default    | Required |
-+====================+=============================================+=============+==========+
-| data-model         | Model name to query                         |             | True     |
-+--------------------+---------------------------------------------+-------------+----------+
-| data-query-field   | Field to query when searching               | name        | False    |
-+--------------------+---------------------------------------------+-------------+----------+
-| data-display-field | Field to display (defaults to query-field)  | query-field | False    |
-+--------------------+---------------------------------------------+-------------+----------+
-| data-limit         | Limit results to this many                  | 10          | False    |
-+--------------------+---------------------------------------------+-------------+----------+
-| data-domain        | Additional domain for query                 | []          | False    |
-+--------------------+---------------------------------------------+-------------+----------+
++--------------------+---------------------------------------------+---------------+----------+
+|  Attribute         |  Description                                |  Default      | Required |
++====================+=============================================+===============+==========+
+| data-model         | Model name to query                         |               | True     |
++--------------------+---------------------------------------------+---------------+----------+
+| data-query-field   | Field to query when searching               | name          | False    |
++--------------------+---------------------------------------------+---------------+----------+
+| data-display-field | Field to display                            | query-field   | False    |
++--------------------+---------------------------------------------+---------------+----------+
+| data-value-field   | Field to use as form value                  | display-field | False    |
++--------------------+---------------------------------------------+---------------+----------+
+| data-limit         | Limit results to this many                  | 10            | False    |
++--------------------+---------------------------------------------+---------------+----------+
+| data-domain        | Additional domain for query                 | []            | False    |
++--------------------+---------------------------------------------+---------------+----------+
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
@@ -53,8 +56,7 @@ Following is a breakdown of the available attributes & their defaults:
 Known Issues / Road Map
 =======================
 
-* Replace jQuery UI Autocomplete w/ HTML5 Datalist when `ready for production
-<http://caniuse.com/#feat=datalist>`_.
+* Replace jQuery UI Autocomplete w/ HTML5 Datalist when `ready for production <http://caniuse.com/#feat=datalist>`_.
 
 
 Bug Tracker

--- a/website_field_autocomplete/README.rst
+++ b/website_field_autocomplete/README.rst
@@ -53,7 +53,8 @@ Following is a breakdown of the available attributes & their defaults:
 Known Issues / Road Map
 =======================
 
-* Use of Model/jsonRPC requires a user session.
+* Replace jQuery UI Autocomplete w/ HTML5 Datalist when `ready for production
+<http://caniuse.com/#feat=datalist>`_.
 
 
 Bug Tracker

--- a/website_field_autocomplete/README.rst
+++ b/website_field_autocomplete/README.rst
@@ -19,27 +19,27 @@ To use this module, you need to add an input field with the
 
     <input type="text"
            class="s_website_autocomplete"
-           data-queryField="name"
-           data-displayField="name"
+           data-query-field="name"
+           data-display-field="name"
            data-limit="5"
            data-domain='[["website_published", "=", true]]'
            data-model="product.template"
            />
 
 
-+-------------------+--------------------------------------------+------------+----------+
-|  Attribute        |  Description                               |  Default   | Required |
-+===================+============================================+============+==========+
-| data-model        | Model name to query                        |            | True     |
-+-------------------+--------------------------------------------+------------+----------+
-| data-queryField   | Field to query when searching              | name       | False    |
-+-------------------+--------------------------------------------+------------+----------+
-| data-displayField | Field to display (defaults to queryField)  | queryField | False    |
-+-------------------+--------------------------------------------+------------+----------+
-| data-limit        | Limit results to this many                 | 10         | False    |
-+-------------------+--------------------------------------------+------------+----------+
-| data-domain       | Additional domain for query                | []         | False    |
-+-------------------+--------------------------------------------+------------+----------+
++--------------------+---------------------------------------------+------------+----------+
+|  Attribute         |  Description                                |  Default   | Required |
++====================+=============================================+============+==========+
+| data-model         | Model name to query                         |            | True     |
++--------------------+---------------------------------------------+------------+----------+
+| data-query-field   | Field to query when searching               | name       | False    |
++--------------------+---------------------------------------------+------------+----------+
+| data-display-field | Field to display (defaults to query-field)  | query-field | False   |
++--------------------+---------------------------------------------+------------+----------+
+| data-limit         | Limit results to this many                  | 10         | False    |
++--------------------+---------------------------------------------+------------+----------+
+| data-domain        | Additional domain for query                 | []         | False    |
++--------------------+---------------------------------------------+------------+----------+
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/website_field_autocomplete/README.rst
+++ b/website_field_autocomplete/README.rst
@@ -15,7 +15,7 @@ Usage
 =====
 
 To use this module, you need to add an input field with the
-``s_website_autocomplete`` class, such as in the below format:
+``js_website_autocomplete`` class, such as in the below format:
 
     <input type="text"
            class="s_website_autocomplete"

--- a/website_field_autocomplete/README.rst
+++ b/website_field_autocomplete/README.rst
@@ -17,29 +17,32 @@ Usage
 To use this module, you need to add an input field with the
 ``js_website_autocomplete`` class, such as in the below format:
 
+.. code:: xml
+
     <input type="text"
-           class="s_website_autocomplete"
+           class="js_website_autocomplete"
            data-query-field="name"
            data-display-field="name"
-           data-limit="5"
+           data-limit="10"
            data-domain='[["website_published", "=", true]]'
            data-model="product.template"
            />
 
+Following is a breakdown of the available attributes & their defaults:
 
-+--------------------+---------------------------------------------+------------+----------+
-|  Attribute         |  Description                                |  Default   | Required |
-+====================+=============================================+============+==========+
-| data-model         | Model name to query                         |            | True     |
-+--------------------+---------------------------------------------+------------+----------+
-| data-query-field   | Field to query when searching               | name       | False    |
-+--------------------+---------------------------------------------+------------+----------+
-| data-display-field | Field to display (defaults to query-field)  | query-field | False   |
-+--------------------+---------------------------------------------+------------+----------+
-| data-limit         | Limit results to this many                  | 10         | False    |
-+--------------------+---------------------------------------------+------------+----------+
-| data-domain        | Additional domain for query                 | []         | False    |
-+--------------------+---------------------------------------------+------------+----------+
++--------------------+---------------------------------------------+-------------+----------+
+|  Attribute         |  Description                                |  Default    | Required |
++====================+=============================================+=============+==========+
+| data-model         | Model name to query                         |             | True     |
++--------------------+---------------------------------------------+-------------+----------+
+| data-query-field   | Field to query when searching               | name        | False    |
++--------------------+---------------------------------------------+-------------+----------+
+| data-display-field | Field to display (defaults to query-field)  | query-field | False    |
++--------------------+---------------------------------------------+-------------+----------+
+| data-limit         | Limit results to this many                  | 10          | False    |
++--------------------+---------------------------------------------+-------------+----------+
+| data-domain        | Additional domain for query                 | []          | False    |
++--------------------+---------------------------------------------+-------------+----------+
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/website_field_autocomplete/README.rst
+++ b/website_field_autocomplete/README.rst
@@ -1,0 +1,86 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+============================
+Website Field - AutoComplete
+============================
+
+Adds an AutoComplete field for use in Odoo Website.
+
+This module is somewhat difficult to use on its own in an effort to not require
+any dependencies other than website.
+
+Usage
+=====
+
+To use this module, you need to add an input field with the
+``s_website_autocomplete`` class, such as in the below format:
+
+    <input type="text"
+           class="s_website_autocomplete"
+           data-queryField="name"
+           data-displayField="name"
+           data-limit="5"
+           data-domain='[["website_published", "=", true]]'
+           data-model="product.template"
+           />
+
+
++-------------------+--------------------------------------------+------------+----------+
+|  Attribute        |  Description                               |  Default   | Required |
++===================+============================================+============+==========+
+| data-model        | Model name to query                        |            | True     |
++-------------------+--------------------------------------------+------------+----------+
+| data-queryField   | Field to query when searching              | name       | False    |
++-------------------+--------------------------------------------+------------+----------+
+| data-displayField | Field to display (defaults to queryField)  | queryField | False    |
++-------------------+--------------------------------------------+------------+----------+
+| data-limit        | Limit results to this many                 | 10         | False    |
++-------------------+--------------------------------------------+------------+----------+
+| data-domain       | Additional domain for query                | []         | False    |
++-------------------+--------------------------------------------+------------+----------+
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/186/9.0
+
+
+Known Issues / Road Map
+=======================
+
+* Use of Model/jsonRPC requires a user session.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/website/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_field_autocomplete/__init__.py
+++ b/website_field_autocomplete/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/website_field_autocomplete/__openerp__.py
+++ b/website_field_autocomplete/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Website Field - AutoComplete",
+    "summary": 'Provides an autocomplete field for Website on any model',
+    "version": "9.0.1.0.0",
+    "category": "Website",
+    "website": "https://laslabs.com/",
+    "author": "LasLabs, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website",
+    ],
+    "data": [
+        'views/assets.xml',
+    ],
+}

--- a/website_field_autocomplete/__openerp__.py
+++ b/website_field_autocomplete/__openerp__.py
@@ -18,4 +18,7 @@
     "data": [
         'views/assets.xml',
     ],
+    'demo': [
+        'demo/field_autocomplete_demo.xml',
+    ]
 }

--- a/website_field_autocomplete/controllers/__init__.py
+++ b/website_field_autocomplete/controllers/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import controllers
+from . import main

--- a/website_field_autocomplete/controllers/main.py
+++ b/website_field_autocomplete/controllers/main.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import json
+from openerp import http
+from openerp.http import request
+from openerp.addons.website.controllers.main import Website
+
+
+class Website(Website):
+
+    @http.route(
+        '/website/field_autocomplete/<string:model>',
+        type='http',
+        auth='public',
+        methods=['GET'],
+        website=True,
+    )
+    def _get_autocomplete_data(self, model, **kwargs):
+        res = []
+        domain = json.loads(kwargs.get('domain', "[]"))
+        fields = json.loads(kwargs.get('fields', "[]"))
+        limit = kwargs.get('limit', None)
+        if limit:
+            limit = int(limit)
+        for rec_id in request.env[model].search(domain, limit=limit):
+            res.append({
+                k: getattr(rec_id, k, None) for k in fields
+            })
+        return json.dumps(res)

--- a/website_field_autocomplete/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete/demo/field_autocomplete_demo.xml
@@ -7,14 +7,16 @@
 
 <odoo>
     <template id="field_autocomplete_demo" name="Field Autocomplete Demo" inherit_id="website.homepage">
-        <xpath expr="//div" position="inside">
-            <div class="row">
+        <xpath expr="//div[@id='wrap']" position="inside">
+            <div class="container">
                 <h1>Partner Autocomplete:</h1>
                 <div class="row">
+                    <label for="name">Name</label>
                     <input type="text"
                            class="js_website_autocomplete"
                            data-query-field="name"
                            data-display-field="name"
+                           data-value-field="id"
                            data-limit="10"
                            data-domain='[["customer", "=", true]]'
                            data-model="res.partner"

--- a/website_field_autocomplete/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete/demo/field_autocomplete_demo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    @license AGPL-3 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    <template id="field_autocomplete_demo" name="Field Autocomplete Demo" inherit_id="website.homepage">
+        <xpath expr="//div" position="inside">
+            <div class="row">
+                <h1>Partner Autocomplete:</h1>
+                <div class="row">
+                    <input type="text"
+                           class="js_website_autocomplete"
+                           data-query-field="name"
+                           data-display-field="name"
+                           data-limit="10"
+                           data-domain='[["customer", "=", true]]'
+                           data-model="res.partner"
+                           />
+                </div>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/website_field_autocomplete/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete/demo/field_autocomplete_demo.xml
@@ -6,23 +6,31 @@
 -->
 
 <odoo>
-    <template id="field_autocomplete_demo" name="Field Autocomplete Demo" inherit_id="website.homepage">
-        <xpath expr="//div[@id='wrap']" position="inside">
-            <div class="container">
-                <h1>Partner Autocomplete:</h1>
-                <div class="row">
-                    <label for="name">Name</label>
-                    <input type="text"
-                           class="js_website_autocomplete"
-                           data-query-field="name"
-                           data-display-field="name"
-                           data-value-field="id"
-                           data-limit="10"
-                           data-domain='[["customer", "=", true]]'
-                           data-model="res.partner"
-                           />
+    <template id="field_autocomplete_demo" name="Field Autocomplete Demo"  page="True">
+        <t t-call="website.layout">
+            <div id="wrap" class="oe_structure oe_empty">
+                <div class="container">
+                    <h1>Partner Autocomplete:</h1>
+                    <div class="row">
+                        <label for="name">Name</label>
+                        <input type="text"
+                               class="js_website_autocomplete"
+                               data-query-field="name"
+                               data-display-field="name"
+                               data-value-field="id"
+                               data-limit="10"
+                               data-domain='[["customer", "=", true]]'
+                               data-model="res.partner"
+                               />
+                    </div>
                 </div>
             </div>
-        </xpath>
+        </t>
     </template>
+    <record id="field_autocomplete_demo_link" model="website.menu">
+        <field name="name">AutoComplete</field>
+        <field name="url">/page/website_field_autocomplete.field_autocomplete_demo</field>
+        <field name="parent_id" ref="website.main_menu" />
+        <field name="sequence" type="int">50</field>
+    </record>
 </odoo>

--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -26,7 +26,7 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
       if (add_domain) {
         domain = domain.concat(add_domain);
       }
-      QueryModel.call('search_read', [domain, [displayField]], {limit: limit})
+      return QueryModel.call('search_read', [domain, [displayField]], {limit: limit})
         .then(function(records) {
           var data = records.reduce(function(a, b) {
             a.push(b[displayField]);

--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -16,20 +16,17 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
      * @param request object Request from jQueryUI Autocomplete
      * @param response function Callback for response, accepts array of str
      */
-    autocomplete: function(self, request, response) {
-      var QueryModel = new Model(self.$target.data('model'));
-      var queryField = self.$target.data('query-field') || 'name';
-      var displayField = self.$target.data('display-field') || queryField;
-      var limit = self.$target.data('limit') || 10;
-      var domain = [[queryField, 'ilike', request.term]];
-      var add_domain = self.$target.data('domain');
-      if (add_domain) {
-        domain = domain.concat(add_domain);
+    autocomplete: function(request, response) {
+      var self = this;
+      var domain = [[this.queryField, 'ilike', request.term]];
+      if (this.add_domain) {
+        domain = domain.concat(this.add_domain);
       }
-      return QueryModel.call('search_read', [domain, [displayField]], {limit: limit})
+      var args = [domain, [this.displayField]];
+      return this.QueryModel.call('search_read', args, {limit: this.limit})
         .then(function(records) {
           var data = records.reduce(function(a, b) {
-            a.push(b[displayField]);
+            a.push(b[self.displayField]);
             return a;
           }, []);
           response(data);
@@ -38,9 +35,14 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
     
     start: function() {
       var self = this;
+      this.QueryModel = new Model(this.$target.data('model'));
+      this.queryField = this.$target.data('query-field') || 'name';
+      this.displayField = this.$target.data('display-field') || this.queryField;
+      this.limit = this.$target.data('limit') || 10;
+      this.add_domain = this.$target.data('domain');
       this.$target.autocomplete({
         source: function(request, response) {
-          self.autocomplete(self, request, response);
+          self.autocomplete(request, response);
         },
       });
     },

--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -1,0 +1,57 @@
+/* Copyright 2016 LasLabs Inc.
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ */
+
+odoo.define('website_field_autocomplete.field_autocomplete', function(require){
+  "use strict";
+
+  var snippet_animation = require('web_editor.snippets.animation');
+  var Model = require('web.Model');
+
+  snippet_animation.registry.field_autocomplete = snippet_animation.Class.extend({
+
+    selector: '.s_website_autocomplete',
+
+    start: function() {
+
+      let self = this;
+
+      this.$target.autocomplete({
+        source: function(request, response) {
+          // Must use var, let yields undefined
+          var QueryModel = new Model(self.$target.data('model'));
+          let queryField = self.$target.data('queryField');
+          if (!queryField) {
+            queryField = 'name';
+          }
+          let displayField = self.$target.data('displayField');
+          if (!displayField) {
+            displayField = queryField;
+          }
+          let limit = self.$target.data('limit');
+          if (!limit) {
+            limit = 10;
+          }
+          let domain = [[queryField, 'ilike', request.term]];
+          let add_domain = self.$target.data('domain');
+          if (add_domain) {
+            domain = domain.concat(add_domain);
+          }
+          QueryModel.call('search_read', [domain, [displayField]], {limit: limit})
+            .then(function(records) {
+              let data = records.reduce(function(a, b) {
+                a.push(b[displayField]);
+                return a;
+              }, []);
+              response(data);
+            });
+        }
+      });
+      
+    },
+    
+  });
+    
+  return {field_autocomplete: snippet_animation.registry.field_autocomplete};
+
+});

--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -31,11 +31,13 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
           limit: self.limit,
         },
       }).then(function(records) {
-          var data = JSON.parse(records).reduce(function(a, b) {
-            a.push(b[self.displayField]);
+          records = JSON.parse(records);
+          var data = records.reduce(function(a, b) {
+            a.push({label: b[self.displayField], value: b[self.valueField]});
             return a;
           }, []);
           response(data);
+          return records;
         });
     },
     
@@ -44,9 +46,13 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
       this.model = this.$target.data('model');
       this.queryField = this.$target.data('query-field') || 'name';
       this.displayField = this.$target.data('display-field') || this.queryField;
+      this.valueField = this.$target.data('value-field') || this.displayField;
       this.limit = this.$target.data('limit') || 10;
       this.add_domain = this.$target.data('domain');
       this.fields = [this.displayField];
+      if (this.valueField != this.displayField) {
+        this.fields.push(this.valueField);
+      }
       this.$target.autocomplete({
         source: function(request, response) {
           self.autocomplete(request, response);

--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -6,7 +6,7 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
   "use strict";
 
   var snippet_animation = require('web_editor.snippets.animation');
-  var Model = require('web.Model');
+  var $ = require('$');
 
   snippet_animation.registry.field_autocomplete = snippet_animation.Class.extend({
 
@@ -22,10 +22,16 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
       if (this.add_domain) {
         domain = domain.concat(this.add_domain);
       }
-      var args = [domain, [this.displayField]];
-      return this.QueryModel.call('search_read', args, {limit: this.limit})
-        .then(function(records) {
-          var data = records.reduce(function(a, b) {
+      return $.ajax({
+        url: '/website/field_autocomplete/' + self.model,
+        method: 'GET',
+        data: {
+          domain: JSON.stringify(domain),
+          fields: JSON.stringify(self.fields),
+          limit: self.limit,
+        },
+      }).then(function(records) {
+          var data = JSON.parse(records).reduce(function(a, b) {
             a.push(b[self.displayField]);
             return a;
           }, []);
@@ -35,11 +41,12 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
     
     start: function() {
       var self = this;
-      this.QueryModel = new Model(this.$target.data('model'));
+      this.model = this.$target.data('model');
       this.queryField = this.$target.data('query-field') || 'name';
       this.displayField = this.$target.data('display-field') || this.queryField;
       this.limit = this.$target.data('limit') || 10;
       this.add_domain = this.$target.data('domain');
+      this.fields = [this.displayField];
       this.$target.autocomplete({
         source: function(request, response) {
           self.autocomplete(request, response);

--- a/website_field_autocomplete/views/assets.xml
+++ b/website_field_autocomplete/views/assets.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    @license AGPL-3 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    <template id="assets_recaptcha" name="website_form_recaptcha Assets" inherit_id="website.assets_frontend">
+        <xpath expr="." position="inside">
+            <script src="/website_field_autocomplete/static/src/js/field_autocomplete.js" />
+        </xpath>
+    </template>
+</odoo>

--- a/website_field_autocomplete/views/assets.xml
+++ b/website_field_autocomplete/views/assets.xml
@@ -6,7 +6,7 @@
 -->
 
 <odoo>
-    <template id="assets_recaptcha" name="website_form_recaptcha Assets" inherit_id="website.assets_frontend">
+    <template id="assets_autocomplete" name="website_field_autocomplete Assets" inherit_id="website.assets_frontend">
         <xpath expr="." position="inside">
             <script src="/website_field_autocomplete/static/src/js/field_autocomplete.js" />
         </xpath>


### PR DESCRIPTION
This module adds an abstract autocomplete field to Odoo website. Activate by adding the `s_website_autocomplete` class to any text input, and provide the necessary data vars (`data-model` being the only required).

I almost feel like this is something that should exist, so maybe I'm doing something wrong or missing something, but I definitely couldn't find any examples of an autocomplete on website.

One downfall of my implementation here is the use of Model & the underlying jsonRPC, which forces a user session for results. This means that in its current form this cannot be used on the product search input, for example, because the desired result would also have the public user receiving an autocomplete.

The only way I could think of to circumvent the use of model would be to just add something in the controller, which seems sloppy. I dunno though, may be worth it.

Let me know if you have any thoughts/suggestions!
