### PR TITLE
[9.0][IMP] website_field_autocomplete: Upgrade for modularity

### DIFF
--- a/website_field_autocomplete/__openerp__.py
+++ b/website_field_autocomplete/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Website Field - AutoComplete",
     "summary": 'Provides an autocomplete field for Website on any model',
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "category": "Website",
     "website": "https://laslabs.com/",
     "author": "LasLabs, Odoo Community Association (OCA)",

--- a/website_field_autocomplete/controllers/main.py
+++ b/website_field_autocomplete/controllers/main.py
@@ -17,15 +17,30 @@ class Website(Website):
         methods=['GET'],
         website=True,
     )
-    def _get_autocomplete_data(self, model, **kwargs):
-        res = []
+    def _get_field_autocomplete(self, model, **kwargs):
+        """ Return json autocomplete data """
         domain = json.loads(kwargs.get('domain', "[]"))
         fields = json.loads(kwargs.get('fields', "[]"))
         limit = kwargs.get('limit', None)
+        res = self._get_autocomplete_data(model, domain, fields, limit)
+        return json.dumps(res.values())
+
+    def _get_autocomplete_data(self, model, domain, fields, limit=None):
+        """ Gets and returns raw record data
+        Params:
+            model: Model name to query on
+            domain: Search domain
+            fields: List of fields to get
+            limit: Limit results to
+        Returns:
+            Dict of record dicts, keyed by ID
+        """
+        res = {}
         if limit:
             limit = int(limit)
-        for rec_id in request.env[model].search(domain, limit=limit):
-            res.append({
+        self.record_ids = request.env[model].search(domain, limit=limit)
+        for rec_id in self.record_ids:
+            res[rec_id.id] = {
                 k: getattr(rec_id, k, None) for k in fields
-            })
-        return json.dumps(res)
+            }
+        return res

--- a/website_field_autocomplete/controllers/main.py
+++ b/website_field_autocomplete/controllers/main.py
@@ -35,12 +35,9 @@ class Website(Website):
         Returns:
             Dict of record dicts, keyed by ID
         """
-        res = {}
         if limit:
             limit = int(limit)
-        self.record_ids = request.env[model].search(domain, limit=limit)
-        for rec_id in self.record_ids:
-            res[rec_id.id] = {
-                k: getattr(rec_id, k, None) for k in fields
-            }
-        return res
+        res = request.env[model].search_read(
+            domain, fields, limit=limit
+        )
+        return {r['id']: r for r in res}

--- a/website_field_autocomplete/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete/demo/field_autocomplete_demo.xml
@@ -10,17 +10,17 @@
         <t t-call="website.layout">
             <div id="wrap" class="oe_structure oe_empty">
                 <div class="container">
-                    <h1>Partner Autocomplete:</h1>
+                    <h1>Website Menu Autocomplete:</h1>
                     <div class="row">
-                        <label for="name">Name</label>
+                        <label for="url">URL</label>
                         <input type="text"
+                               name="url"
                                class="js_website_autocomplete"
                                data-query-field="name"
                                data-display-field="name"
-                               data-value-field="id"
+                               data-value-field="url"
                                data-limit="10"
-                               data-domain='[["customer", "=", true]]'
-                               data-model="res.partner"
+                               data-model="website.menu"
                                />
                     </div>
                 </div>

--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -23,6 +23,7 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
         domain = domain.concat(this.add_domain);
       }
       return $.ajax({
+        dataType: 'json',
         url: '/website/field_autocomplete/' + self.model,
         method: 'GET',
         data: {
@@ -31,7 +32,6 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
           limit: self.limit,
         },
       }).then(function(records) {
-          records = JSON.parse(records);
           var data = records.reduce(function(a, b) {
             a.push({label: b[self.displayField], value: b[self.valueField]});
             return a;
@@ -41,8 +41,16 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
         });
     },
     
+    /* Return arguments that are used to initialize autocomplete */
+    autocompleteArgs: function() {
+      return {
+        source: function(request, response) {
+          this.autocomplete(request, response);
+        },
+      };
+    },
+    
     start: function() {
-      var self = this;
       this.model = this.$target.data('model');
       this.queryField = this.$target.data('query-field') || 'name';
       this.displayField = this.$target.data('display-field') || this.queryField;
@@ -53,11 +61,7 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
       if (this.valueField != this.displayField) {
         this.fields.push(this.valueField);
       }
-      this.$target.autocomplete({
-        source: function(request, response) {
-          self.autocomplete(request, response);
-        },
-      });
+      this.$target.autocomplete(this.autocompleteArgs());
     },
     
   });

--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -43,10 +43,11 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
     
     /* Return arguments that are used to initialize autocomplete */
     autocompleteArgs: function() {
+      var self = this;
       return {
         source: function(request, response) {
-          this.autocomplete(request, response);
-        },
+          self.autocomplete(request, response);
+        }
       };
     },
     


### PR DESCRIPTION
Fairly straightforward upgrade here- I just split the controller data getter into two methods & added a `self.record_ids` representing the search data in order to allow for easier manipulation before handing back to client.

While I was there I noticed I was being stupid and not defining the dataType in the AJAX call, so I fixed that too.
