### PR TITLE
[ADD][9.0] New Module: website_field_autocomplete_tag

### DIFF
--- a/website_field_autocomplete_tag/README.rst
+++ b/website_field_autocomplete_tag/README.rst
@@ -1,0 +1,73 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============================
+Website Field AutoComplete Tag
+==============================
+
+Extends Website Autocomplete field to allow for selecting of multiple
+results, aka tagging.
+
+Tags are represented as comma separated lists.
+
+Usage
+=====
+
+To use this module, you would follow the instructions provided in
+``website_field_autocomplete``.
+
+In order to activate the tagging feature, you should use the `data-is-tag`
+attribute. Following is an example:
+
+.. code:: xml
+
+    <label for="name">Name</label>
+    <input type="text"
+           name="name"
+           class="js_website_autocomplete"
+           data-query-field="name"
+           data-relate-recv="res_partner"
+           data-model="res.partner"
+           data-is-tag=""
+           />
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/186/9.0
+
+Known Issues / Road Map
+=======================
+
+* Things will get hairy if the data has commas
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/website/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_field_autocomplete_tag/README.rst
+++ b/website_field_autocomplete_tag/README.rst
@@ -29,7 +29,7 @@ attribute. Following is an example:
            data-query-field="name"
            data-relate-recv="res_partner"
            data-model="res.partner"
-           data-is-tag=""
+           data-is-tag="1"
            />
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/website_field_autocomplete_tag/__init__.py
+++ b/website_field_autocomplete_tag/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/website_field_autocomplete_tag/__openerp__.py
+++ b/website_field_autocomplete_tag/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Website Field AutoComplete Tag",
+    "summary": 'Extends website autocomplete field to allow selecting '
+               'multiple results (tagging).',
+    "version": "9.0.1.0.0",
+    "category": "Website",
+    "website": "https://laslabs.com/",
+    "author": "LasLabs, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website_field_autocomplete",
+    ],
+    "data": [
+        'views/assets.xml',
+    ],
+    'demo': [
+        'demo/field_autocomplete_demo.xml',
+    ]
+}

--- a/website_field_autocomplete_tag/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete_tag/demo/field_autocomplete_demo.xml
@@ -6,10 +6,10 @@
 -->
 
 <odoo>
-    <template id="field_autocomplete_demo" name="Field Autocomplete Demo" inherit_id="website_field_autocomplete.field_autocomplete_demo">
+    <template id="field_autocomplete_demo" name="Field Autocomplete Tag Demo" inherit_id="website_field_autocomplete.field_autocomplete_demo">
         <xpath expr="//div[@class='row']" position="after">
             <div class="row">
-                <h1>Partner Autocomplete Tag:</h1>
+                <h1>Autocomplete Tag:</h1>
                 <div class="row">
                     <label for="name">Name</label>
                     <input type="text"
@@ -17,8 +17,8 @@
                            class="js_website_autocomplete"
                            data-query-field="name"
                            data-relate-recv="res_partner"
-                           data-model="res.partner"
-                           data-is-tag=""
+                           data-model="website.menu"
+                           data-is-tag="1"
                            />
                 </div>
             </div>

--- a/website_field_autocomplete_tag/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete_tag/demo/field_autocomplete_demo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    @license AGPL-3 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    <template id="field_autocomplete_demo" name="Field Autocomplete Demo" inherit_id="website_field_autocomplete.field_autocomplete_demo">
+        <xpath expr="//div[@class='row']" position="after">
+            <div class="row">
+                <h1>Partner Autocomplete Tag:</h1>
+                <div class="row">
+                    <label for="name">Name</label>
+                    <input type="text"
+                           name="name"
+                           class="js_website_autocomplete"
+                           data-query-field="name"
+                           data-relate-recv="res_partner"
+                           data-model="res.partner"
+                           data-is-tag=""
+                           />
+                </div>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/website_field_autocomplete_tag/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete_tag/static/src/js/field_autocomplete.js
@@ -1,0 +1,41 @@
+/* Copyright 2016 LasLabs Inc.
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ */
+
+odoo.define('website_field_autocomplete_related.field_autocomplete', function(require){
+  "use strict";
+
+  var snippet_animation = require('web_editor.snippets.animation');
+
+  snippet_animation.registry.field_autocomplete = snippet_animation.registry.field_autocomplete.extend({
+
+    autocomplete: function(request, response) {
+      if (this.$target.data('is-tag') !== undefined) {
+        request.term = request.term.split( /,\s*/ ).pop();
+      }
+      return this._super(request, response);
+    },
+  
+    autocompleteArgs: function() {
+      var res = this._super();
+      if (this.$target.data('is-tag') !== undefined) {
+        res.select = function(event, ui) {
+          var terms = this.value.split( /,\s*/ );
+          terms.pop();
+          terms.push(ui.item.value);
+          terms.push("");
+          this.value = terms.join(', ');
+          return false;
+        };
+        res.focus = function() {
+          return false;
+        };
+      }
+      return res;
+    },
+    
+  });
+    
+  return {field_autocomplete: snippet_animation.registry.field_autocomplete};
+
+});

--- a/website_field_autocomplete_tag/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete_tag/static/src/js/field_autocomplete.js
@@ -18,7 +18,7 @@ odoo.define('website_field_autocomplete_related.field_autocomplete', function(re
   
     autocompleteArgs: function() {
       var res = this._super();
-      if (this.$target.data('is-tag') !== undefined) {
+      if (this.$target.data('is-tag') == "1") {
         res.select = function(event, ui) {
           var terms = this.value.split( /,\s*/ );
           terms.pop();

--- a/website_field_autocomplete_tag/views/assets.xml
+++ b/website_field_autocomplete_tag/views/assets.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    @license AGPL-3 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    <template id="assets_autocomplete_related" name="website_field_autocomplete_related Assets" inherit_id="website.assets_frontend">
+        <xpath expr="." position="inside">
+            <script src="/website_field_autocomplete_tag/static/src/js/field_autocomplete.js" />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Depends on #228 

Simple module here that just injects tagging functionality with the `data-is-tag` attribute on an autocomplete field. Tags are represented as comma separated list.
