### PR TITLE
[8.0][IMP][website_legal_page] Make template texts inheritable.

### DIFF
--- a/website_legal_page/__openerp__.py
+++ b/website_legal_page/__openerp__.py
@@ -23,7 +23,7 @@
 {
     'name': "Website legal page",
     'category': 'Website',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.1.0',
     'depends': [
         'website',
     ],
@@ -34,8 +34,9 @@
         'views/website_terms.xml',
     ],
     'author': 'Antiun Ingeniería S.L., '
+              'Tecnativa, '
               'Odoo Community Association (OCA)',
-    'website': 'http://www.antiun.com',
+    'website': 'http://www.tecnativa.com',
     'license': 'AGPL-3',
     'demo': [],
     'test': [],

--- a/website_legal_page/views/reusable_templates.xml
+++ b/website_legal_page/views/reusable_templates.xml
@@ -4,9 +4,13 @@
 
 <!-- Base templates for submodules -->
 <template id="acceptance_full">
-    I accept the <a href="/page/legal">legal advice</a>, the
-    <a href="/page/privacy">privacy policy</a>, and the
-    <a href="/page/terms">terms of use</a> of this website.
+    <t name="root">
+        <t name="accept">I accept the</t>
+        <a href="/page/legal">legal advice</a><t name="the1">, the</t>
+        <a href="/page/privacy">privacy policy</a><t name="the2">, and the</t>
+        <a href="/page/terms">terms of use</a>
+        <t name="website">of this website.</t>
+    </t>
 </template>
 
 </data>


### PR DESCRIPTION
If you need to change anything other than the URLs in this template, it's near to impossible.

I provide some hooks for that here. Just in case your legal pages are hosted somewhere else, or you don't have a legal advice, etc.

You should notice no change in UI.

@Tecnativa.
