### PR TITLE
[9.0][MIG] website_backend_views to v9

### DIFF
--- a/website_backend_views/__init__.py
+++ b/website_backend_views/__init__.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Therp BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import model
 from . import controllers

--- a/website_backend_views/__openerp__.py
+++ b/website_backend_views/__openerp__.py
@@ -1,27 +1,11 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Therp BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 {
     "name": "Backend views for website",
-    "version": "8.0.1.0.0",
-    "author": "Therp BV,Odoo Community Association (OCA)",
+    "version": "9.0.1.0.0",
+    "author": "Therp BV, LasLabs, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Dependency",
     "summary": "Hook backend views into your website frontend",
@@ -35,12 +19,5 @@
     "demo": [
         "view/demo.xml",
     ],
-    "test": [
-    ],
-    "auto_install": False,
-    'installable': False,
-    "application": False,
-    "external_dependencies": {
-        'python': [],
-    },
+    'installable': True,
 }

--- a/website_backend_views/controllers/__init__.py
+++ b/website_backend_views/controllers/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Therp BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import demo

--- a/website_backend_views/controllers/demo.py
+++ b/website_backend_views/controllers/demo.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Therp BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import http, _
 
 

--- a/website_backend_views/model/__init__.py
+++ b/website_backend_views/model/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2015 Therp BV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import website_qweb
+from . import ir_qweb

--- a/website_backend_views/model/__init__.py
+++ b/website_backend_views/model/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Therp BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import website_qweb

--- a/website_backend_views/model/ir_qweb.py
+++ b/website_backend_views/model/ir_qweb.py
@@ -10,8 +10,8 @@ from lxml import etree
 from openerp import models, _
 
 
-class WebsiteQweb(models.Model):
-    _inherit = 'website.qweb'
+class IrQweb(models.Model):
+    _inherit = 'ir.qweb'
 
     def render_tag_website_backend_view(
             self, element, template_attributes, generated_attributes,

--- a/website_backend_views/model/website_qweb.py
+++ b/website_backend_views/model/website_qweb.py
@@ -1,26 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV (<http://therp.nl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-import simplejson
+# Copyright 2015 Therp BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+try:
+    import json as json
+except ImportError:
+    import json
 from lxml import etree
-from openerp import models
+from openerp import models, _
 
 
 class WebsiteQweb(models.Model):
@@ -29,12 +16,12 @@ class WebsiteQweb(models.Model):
     def render_tag_website_backend_view(
             self, element, template_attributes, generated_attributes,
             qwebcontext):
-        options = simplejson.loads(
+        options = json.loads(
             template_attributes.get('website-backend-view', '{}'))
         model = self.pool.get(options.get('res_model'))
         if not model:
             raise NameError(
-                'Unknown model "%s" or no model defined' %
+                _('Unknown model "%s" or no model defined') %
                 options.get('res_model'))
         # we do the nested divs only in for the backend's css rules to work
         etree.SubElement(
@@ -57,7 +44,7 @@ class WebsiteQweb(models.Model):
                 'data-website-backend-view-id': options.get('view_id', ''),
                 'data-website-backend-view-res-id': str(
                     options.get('res_id', '')),
-                'data-website-backend-view-domain': simplejson.dumps(
+                'data-website-backend-view-domain': json.dumps(
                     options.get('domain', '{}')),
             })
         etree.SubElement(

--- a/website_backend_views/static/src/js/website_backend_views.js
+++ b/website_backend_views/static/src/js/website_backend_views.js
@@ -1,39 +1,29 @@
-//-*- coding: utf-8 -*-
-//############################################################################
-//
-//   OpenERP, Open Source Management Solution
-//   This module copyright (C) 2015 Therp BV <http://therp.nl>.
-//
-//   This program is free software: you can redistribute it and/or modify
-//   it under the terms of the GNU Affero General Public License as
-//   published by the Free Software Foundation, either version 3 of the
-//   License, or (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU Affero General Public License for more details.
-//
-//   You should have received a copy of the GNU Affero General Public License
-//   along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//
-//############################################################################
-(function()
+/* Copyright 2015 Therp BV
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ */
+
+odoo.define('website_backed_views.backend_views', function(require)
 {
-    openerp.website.dom_ready.then(function()
-    {
-        var views = jQuery('[data-website-backend-view-model]');
+    'use strict';
+    
+    var base = require('web_editor.base');
+    var ActionManager = require('web.ActionManager');
+    var WebClient = require('web.WebClient');
+    var $ = require('$');
+    
+    base.ready().done(function() {
+        var views = $('[data-website-backend-view-model]');
         if(!views.length)
         {
             return;
         }
         var backend = openerp.init();
-        backend.client = new backend.web.WebClient();
+        backend.client = new WebClient();
         backend.client.start().then(function()
         {
-            views.each(function(i, view)
+            _.each(views, function(view)
             {
-                view = jQuery(view);
+                view = $(view);
                 var action = {
                     'type': 'ir.actions.act_window',
                     'res_model': view.data('website-backend-view-model'),
@@ -46,7 +36,7 @@
                     ],
                     'domain': view.data('website-backend-view-domain') || [],
                 };
-                var action_manager = new backend.web.ActionManager(backend.client);
+                var action_manager = new ActionManager(backend.client);
                 var view_manager = new backend.web.ViewManagerAction(
                         action_manager, action);
                 view_manager.setElement(view);
@@ -55,4 +45,4 @@
             });
         });
     });
-})()
+});

--- a/website_backend_views/view/demo.xml
+++ b/website_backend_views/view/demo.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data>
-        <template id="demo_index">
-            <t t-call="website.layout">
-                <h1>Beneath you'll see an edit form for your main partner. Should work</h1>
-                <!-- this wil end up in a window action with the appropriate fields set /-->
-                <t t-website-backend-view='{"res_model": "res.partner", "view_type": "form", "res_id": %(base.main_partner)s, "domain": [["id", "=", %(base.main_partner)s]]}' />
-                <div>And of course, you can do whatever you want with the rest of the page. Maybe hide the manager's buttons and provide a nicer UI for saving?</div>
-            </t>
-        </template>
-    </data>
-</openerp>
+<odoo>
+    <template id="demo_index">
+        <t t-call="website.layout">
+            <h1>Beneath you'll see an edit form for your main partner. Should work</h1>
+            <!-- this wil end up in a window action with the appropriate fields set /-->
+            <t t-website-backend-view='{"res_model": "res.partner", "view_type": "form", "res_id": %(base.main_partner)s, "domain": [["id", "=", %(base.main_partner)s]]}' />
+            <div>And of course, you can do whatever you want with the rest of the page. Maybe hide the manager's buttons and provide a nicer UI for saving?</div>
+        </t>
+    </template>
+</odoo>

--- a/website_backend_views/view/templates.xml
+++ b/website_backend_views/view/templates.xml
@@ -1,23 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data>
-        <template id="assets_frontend" name="website_backend_views assets" inherit_id="website.assets_frontend">
-            <xpath expr="." position="inside">
-                <script type="text/javascript" src="/website_backend_views/static/src/js/website_backend_views.js"></script>
-                <link rel="stylesheet" href="/website_backend_views/static/src/css/website_backend_views.css"/>
-            </xpath>
-        </template>
-        <template id="layout" inherit_id="website.layout">
-            <xpath expr="//t[@t-call-assets='website.assets_frontend' and @t-js='false']" position="after">
-                <t t-if="website_backend_views_active">
-                    <t t-call-assets="web.assets_backend" t-js="false" />
-                </t>
-            </xpath>
-            <xpath expr="//t[@t-call-assets='web.assets_common' and @t-css='false']" position="after">
-                <t t-if="website_backend_views_active">
-                    <t t-call-assets="web.assets_backend" t-css="false" />
-                </t>
-            </xpath>
-        </template>
-    </data>
-</openerp>
+<odoo>
+    <template id="assets_frontend" name="website_backend_views assets" inherit_id="website.assets_frontend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/website_backend_views/static/src/js/website_backend_views.js"></script>
+            <link rel="stylesheet" href="/website_backend_views/static/src/css/website_backend_views.css"/>
+        </xpath>
+    </template>
+    <template id="layout" inherit_id="website.layout">
+        <xpath expr="//t[@t-call-assets='website.assets_frontend' and @t-js='false']" position="after">
+            <t t-if="website_backend_views_active">
+                <t t-call-assets="web.assets_backend" t-js="false" />
+            </t>
+        </xpath>
+        <xpath expr="//t[@t-call-assets='web.assets_common' and @t-css='false']" position="after">
+            <t t-if="website_backend_views_active">
+                <t t-call-assets="web.assets_backend" t-css="false" />
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This upgrades website_backend_views to v9.

It should work, although I haven't tested much. This is a WIP because with the fix I found in OCA/web#402 for [public data sessions](https://github.com/OCA/web/pull/402/commits/33ee3ae91e66e687af7cab6195383ffd2ac2456d), I believe this is the key for OCA/web#403 instead of the standalone session module. 
