### PR TITLE
[IMP][website_seo_redirection] New features and bug fixes. (#246)

### DIFF
--- a/website_seo_redirection/README.rst
+++ b/website_seo_redirection/README.rst
@@ -12,6 +12,9 @@ URLs and allow you to improve the SEO.
 Usage
 =====
 
+Moving a page to another URL
+----------------------------
+
 Let's assume you created a blog post entry that is absolutely amazing and you
 want a fixed and beautiful URL for it. That entry is posted in
 ``https://example.com/blog/our-news-1/post/amazing-post-23``, but you want it
@@ -19,10 +22,28 @@ at ``https://example.com/amazing``. You need to:
 
 #. Go to *Website Admin > SEO Redirections > Create*.
 #. Set ``/blog/our-news-1/post/amazing-post-23`` as *Original URL*.
-#. Set ``/amazing`` as *Redirected URL*.
+#. Set ``/amazing`` as *Destination URL*.
+#. Enable *Relocate controller*.
 
 Now navigate to any of both URLs, and you will get to the blog post, but with
 the URL you wanted.
+
+Setting a URL as a redirection to another one
+---------------------------------------------
+
+Let's assume you created a blog post entry that is absolutely amazing and you
+want a shortened URL that redirects to it. That entry is posted in
+``https://example.com/blog/our-news-1/post/amazing-post-23``, but you want that
+``https://example.com/amazing`` redirects to it. You need to:
+
+#. Go to *Settings > Configuration > SEO Redirections > Create*.
+#. Set ``/amazing`` as *Original URL*.
+#. Set ``/blog/our-news-1/post/amazing-post-23`` as *Destination URL*.
+#. Disable *Relocate controller*.
+
+Now navigate to any of both URLs, and you will get to the blog post, with its
+original URL untouched.
+
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -31,10 +52,15 @@ the URL you wanted.
 Known issues / Roadmap
 ======================
 
-* The frontend *Promote* view should be extended to display and modify this
-  information more easily.
-* Add ability to have several redirected URLs for a single original URL.
+* Redirections are cached. If you hit one once, and then change it, you will
+  mostly have to clear your browser's cache to avoid hitting a 404 error.
 * Make it multiwebsite-compatible.
+
+Notes for migration to v10:
+
+* `#4146 <https://github.com/odoo/odoo/issues/4146>`_ was fixed, so we could
+  make the *Promote* panel load data from an extended ``website.seo.metadata``
+  class.
 
 Bug Tracker
 ===========

--- a/website_seo_redirection/__openerp__.py
+++ b/website_seo_redirection/__openerp__.py
@@ -20,6 +20,7 @@
         "views/website_seo_redirection_view.xml",
     ],
     "demo": [
+        "demo/assets_demo.xml",
         "demo/website_seo_redirection_demo.xml",
     ],
 }

--- a/website_seo_redirection/__openerp__.py
+++ b/website_seo_redirection/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Website SEO Redirection",
     "summary": "Redirect any controller to the URL of your dreams",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.1.0",
     "category": "Website",
     "website": "https://tecnativa.com/",
     "author": "Tecnativa, LasLabs, Odoo Community Association (OCA)",

--- a/website_seo_redirection/demo/assets_demo.xml
+++ b/website_seo_redirection/demo/assets_demo.xml
@@ -4,10 +4,10 @@
 
 <odoo>
 
-<template id="assets_editor" inherit_id="website.assets_editor">
+<template id="assets_frontend_demo" inherit_id="website.assets_frontend">
     <xpath expr=".">
         <script type="text/javascript"
-                src="/website_seo_redirection/static/src/js/website_seo.js"/>
+                src="/website_seo_redirection/static/src/js/website_seo_redirection.tour.js"/>
     </xpath>
 </template>
 

--- a/website_seo_redirection/demo/website_seo_redirection_demo.xml
+++ b/website_seo_redirection/demo/website_seo_redirection_demo.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
-
 <odoo>
 
 <template id="sample_page" page="True">
@@ -45,6 +44,12 @@
 <record id="sample_redirection" model="website.seo.redirection">
     <field name="origin">/page/website_seo_redirection.sample_page</field>
     <field name="destination">/seo/sample</field>
+</record>
+
+<record id="sample_redirection_no_relocate" model="website.seo.redirection">
+    <field name="origin">/seo/sample/no-relocate</field>
+    <field name="destination">/seo/sample</field>
+    <field name="relocate_controller" eval="False"/>
 </record>
 
 </odoo>

--- a/website_seo_redirection/i18n/es.po
+++ b/website_seo_redirection/i18n/es.po
@@ -1,63 +1,85 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_seo_redirection
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-13 02:52+0000\n"
-"PO-Revision-Date: 2016-09-13 02:52+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"POT-Creation-Date: 2016-09-01 13:03+0200\n"
+"PO-Revision-Date: 2016-09-01 13:06+0200\n"
+"Last-Translator: Jairo Llopis <jairo.llopis@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.8\n"
 
 #. module: website_seo_redirection
-#: code:addons/website_seo_redirection/models/website_seo_redirection.py:50
+#: code:addons/website_seo_redirection/models/website_seo_redirection.py:77
 #, python-format
 msgid "%s must start with `/`"
 msgstr "%s debe comenzar por \"/\""
 
 #. module: website_seo_redirection
-#: model:ir.ui.view,arch_db:website_seo_redirection.sample_page
+#: view:website:website_seo_redirection.sample_page
 msgid ", but"
 msgstr ", pero"
 
 #. module: website_seo_redirection
-#: model:ir.ui.view,arch_db:website_seo_redirection.sample_page
+#: view:website:website_seo_redirection.sample_page
 msgid "/page/website_seo_redirection.sample_page"
 msgstr "/page/website_seo_redirection.sample_page"
 
 #. module: website_seo_redirection
-#: model:ir.ui.view,arch_db:website_seo_redirection.sample_page
+#: view:website:website_seo_redirection.sample_page
 msgid "/seo/sample"
 msgstr "/seo/sample"
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_create_uid
+#. openerp-web
+#: code:addons/website_seo_redirection/static/src/xml/website_seo.xml:13
+#, python-format
+msgid "BEWARE!"
+msgstr "¡CUIDADO!"
+
+#. module: website_seo_redirection
+#. openerp-web
+#: code:addons/website_seo_redirection/static/src/xml/website_seo.xml:8
+#, python-format
+msgid "Change the URL"
+msgstr "Cambiar la URL"
+
+#. module: website_seo_redirection
+#: field:website.seo.redirection,create_uid:0
 msgid "Created by"
 msgstr "Creado por"
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_create_date
+#: field:website.seo.redirection,create_date:0
 msgid "Created on"
 msgstr "Creado en"
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_display_name
-msgid "Display Name"
-msgstr "Nombre mostrado"
+#: field:website.seo.redirection,destination:0
+msgid "Destination URL"
+msgstr "URL de destino"
 
 #. module: website_seo_redirection
-#: sql_constraint:website.seo.redirection:0
-msgid "Duplicated new URL"
-msgstr ""
+#. openerp-web
+#: code:addons/website_seo_redirection/static/src/xml/website_seo.xml:22
+#, python-format
+msgid "Destination URL:"
+msgstr "URL de destino:"
+
+#. module: website_seo_redirection
+#: field:website.seo.redirection,display_name:0
+msgid "Display Name"
+msgstr "Nombre mostrado"
 
 #. module: website_seo_redirection
 #: sql_constraint:website.seo.redirection:0
@@ -65,10 +87,17 @@ msgid "Duplicated original URL"
 msgstr "URL original duplicada"
 
 #. module: website_seo_redirection
-#: code:addons/website_seo_redirection/models/website_seo_redirection.py:118
+#: code:addons/website_seo_redirection/models/website_seo_redirection.py:149
 #, python-format
 msgid "Duplicated redirection."
 msgstr "Redirección duplicada."
+
+#. module: website_seo_redirection
+#. openerp-web
+#: code:addons/website_seo_redirection/static/src/xml/website_seo.xml:33
+#, python-format
+msgid "E.g.: /some/good-url"
+msgstr "Ej.: /una/buena-url"
 
 #. module: website_seo_redirection
 #: model:ir.model,name:website_seo_redirection.model_ir_http
@@ -76,64 +105,105 @@ msgid "HTTP routing"
 msgstr "Enrutamiento HTTP"
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_id
+#: field:website.seo.redirection,id:0
 msgid "ID"
-msgstr "ID"
+msgstr "ID (identificación)"
 
 #. module: website_seo_redirection
-#: code:addons/website_seo_redirection/models/website_seo_redirection.py:54
+#. openerp-web
+#: code:addons/website_seo_redirection/static/src/xml/website_seo.xml:16
+#, python-format
+msgid ""
+"If you need a special URL for this page, you can set it here, but if you set "
+"some URL that is already in use, could be interferring with other page and "
+"bad things could happen..."
+msgstr ""
+"Si necesita una URL especial para esta página, puede establecerla aquí, pero "
+"si establece una URL que ya está en uso, podría interferir con otra página y "
+"podría haber problemas..."
+
+#. module: website_seo_redirection
+#: help:website.seo.redirection,relocate_controller:0
+msgid ""
+"If you relocate the controller, the same page that was found in the original "
+"URL will be now in the destination. Otherwise, this will simply make "
+"requests be redirected, but a new controller should be available in the "
+"destination URL if you do not want a 404 error."
+msgstr ""
+"Si reubica el controlador, la misma página que se encontraba en la URL "
+"original estará ahora en la de destino. En caso contrario, esto simplemente "
+"hará que las solicitudes se redireccionen, pero debería haber un nuevo "
+"controlador disponible en la URL de destino si no quiere un error 404."
+
+#. module: website_seo_redirection
+#: code:addons/website_seo_redirection/models/website_seo_redirection.py:81
 #, python-format
 msgid "Invalid character found in %s: `%s`"
 msgstr "Se ha encontrado un carácter no válido en %s: \"%s\""
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection___last_update
+#: field:website.seo.redirection,__last_update:0
 msgid "Last Modified on"
 msgstr "Última modificación el"
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_write_uid
+#: field:website.seo.redirection,write_uid:0
 msgid "Last Updated by"
-msgstr "Última actualización por"
+msgstr "Última actualización de"
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_write_date
+#: field:website.seo.redirection,write_date:0
 msgid "Last Updated on"
-msgstr "Última actualización el"
+msgstr "Última actualización en"
 
 #. module: website_seo_redirection
-#: code:addons/website_seo_redirection/models/website_seo_redirection.py:78
+#: code:addons/website_seo_redirection/models/website_seo_redirection.py:109
 #, python-format
 msgid "No origin found for this redirection."
 msgstr "No se ha encontrado ningún origen para esta redirección."
 
 #. module: website_seo_redirection
-#: code:addons/website_seo_redirection/models/website_seo_redirection.py:116
+#: code:addons/website_seo_redirection/models/website_seo_redirection.py:147
 #, python-format
 msgid "No redirection target found."
 msgstr "No se ha encontrado ningún destino."
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_origin
 #: model:website.menu,name:website_seo_redirection.sample_origin_menu
+#: field:website.seo.redirection,origin:0
 msgid "Original URL"
 msgstr "URL original"
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,help:website_seo_redirection.field_website_seo_redirection_destination
+#: help:website.seo.redirection,destination:0
 msgid "Path where the controller will be found now."
 msgstr "Ruta donde el controlador se encontrará ahora."
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,help:website_seo_redirection.field_website_seo_redirection_origin
+#: help:website.seo.redirection,origin:0
 msgid "Path where the original controller was found."
 msgstr "Ruta donde se encontraba el controlador original."
 
 #. module: website_seo_redirection
-#: model:ir.model.fields,field_description:website_seo_redirection.field_website_seo_redirection_destination
+#: code:addons/website_seo_redirection/models/website_seo_redirection.py:68
+#, python-format
+msgid "Recursive redirection is forbidden."
+msgstr "Las redirecciones recursivas están prohibidas."
+
+#. module: website_seo_redirection
+#: sql_constraint:website.seo.redirection:0
+msgid "Recursive redirection."
+msgstr "Redirección recursiva."
+
+#. module: website_seo_redirection
 #: model:website.menu,name:website_seo_redirection.sample_destination_menu
 msgid "Redirected URL"
 msgstr "URL redireccionada"
+
+#. module: website_seo_redirection
+#: field:website.seo.redirection,relocate_controller:0
+msgid "Relocate controller"
+msgstr "Reubicar controlador"
 
 #. module: website_seo_redirection
 #: model:ir.actions.act_window,name:website_seo_redirection.website_seo_redirection_action_open
@@ -152,22 +222,34 @@ msgid "SEO controller redirections"
 msgstr "Redirecciones de controladores SEO"
 
 #. module: website_seo_redirection
-#: model:ir.ui.view,arch_db:website_seo_redirection.sample_page
+#: view:website:website_seo_redirection.sample_page
 msgid "The original URL for this page is"
 msgstr "La URL original para esta página es"
 
 #. module: website_seo_redirection
-#: model:ir.ui.view,arch_db:website_seo_redirection.sample_page
+#. openerp-web
+#: code:addons/website_seo_redirection/static/src/xml/website_seo.xml:33
+#, python-format
+msgid "URL without domain name, all lower case, hyphenated."
+msgstr "URL sin nombre de dominio, todo en minúsculas, separada por guiones."
+
+#. module: website_seo_redirection
+#: model:ir.model,name:website_seo_redirection.model_website
+msgid "Website"
+msgstr "Sitio web"
+
+#. module: website_seo_redirection
+#: view:website:website_seo_redirection.sample_page
 msgid "Welcome, this is SEO."
 msgstr "Bienvenido, esto es SEO."
 
 #. module: website_seo_redirection
-#: code:addons/website_seo_redirection/models/website_seo_redirection.py:58
+#: code:addons/website_seo_redirection/models/website_seo_redirection.py:85
 #, python-format
 msgid "You cannot redirect an URL to itself."
 msgstr "No puede redireccionar una URL a sí misma."
 
 #. module: website_seo_redirection
-#: model:ir.ui.view,arch_db:website_seo_redirection.sample_page
+#: view:website:website_seo_redirection.sample_page
 msgid "is beautier, right?"
 msgstr "es más bonita, ¿verdad?"

--- a/website_seo_redirection/migrations/8.0.1.1.0/pre-migrate.py
+++ b/website_seo_redirection/migrations/8.0.1.1.0/pre-migrate.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+def migrate(cr, version):
+    """Now you can have multiple origins for a destination."""
+    cr.execute("""ALTER TABLE website_seo_redirection
+                  DROP CONSTRAINT IF EXISTS
+                  website_seo_redirection_destination_unique""")

--- a/website_seo_redirection/models/__init__.py
+++ b/website_seo_redirection/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
-from . import ir_http, website_seo_redirection
+from . import ir_http
+from . import website_seo_redirection
+from . import website

--- a/website_seo_redirection/models/ir_http.py
+++ b/website_seo_redirection/models/ir_http.py
@@ -4,6 +4,7 @@
 
 from openerp import models
 from openerp.http import request
+
 from ..exceptions import NoOriginError, NoRedirectionError
 
 

--- a/website_seo_redirection/models/website.py
+++ b/website_seo_redirection/models/website.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from openerp import api, models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    @api.multi
+    def enumerate_pages(self, query_string=None):
+        """Show redirected URLs in search results."""
+        query = query_string or ""
+        seo_redirections = list()
+        redirection_records = self.env["website.seo.redirection"].search([
+            "|", ("origin", "ilike", query),
+            ("destination", "ilike", query),
+        ])
+        for record in redirection_records:
+            for url in record.origin, record.destination:
+                if url not in seo_redirections:
+                    seo_redirections.append(url)
+        for page in super(Website, self).enumerate_pages(query_string):
+            try:
+                seo_redirections.remove(page["loc"])
+            except ValueError:
+                pass
+            yield page
+        for page in seo_redirections:
+            yield {"loc": page}

--- a/website_seo_redirection/models/website_seo_redirection.py
+++ b/website_seo_redirection/models/website_seo_redirection.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 # © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from psycopg2 import IntegrityError
 
 from openerp import _, api, fields, models
-from openerp.http import request, local_redirect
+from openerp.http import local_redirect, request
 from openerp.exceptions import ValidationError
+
 from ..exceptions import NoOriginError, NoRedirectionError
 
 
@@ -15,7 +17,9 @@ class WebsiteSeoRedirection(models.Model):
     _description = "SEO controller redirections"
     _sql_constraints = [
         ("origin_unique", "UNIQUE(origin)", "Duplicated original URL"),
-        ("destination_unique", "UNIQUE(destination)", "Duplicated new URL"),
+        ("origin_destination_distinct",
+         "CHECK(origin != destination)",
+         "Recursive redirection."),
     ]
 
     origin = fields.Char(
@@ -25,10 +29,18 @@ class WebsiteSeoRedirection(models.Model):
         help="Path where the original controller was found.",
     )
     destination = fields.Char(
-        string="Redirected URL",
+        string="Destination URL",
         required=True,
         index=True,
         help="Path where the controller will be found now.",
+    )
+    relocate_controller = fields.Boolean(
+        default=True,
+        help="If you relocate the controller, the same page that was found in "
+             "the original URL will be now in the destination. Otherwise, "
+             "this will simply make requests be redirected, but a new "
+             "controller should be available in the destination URL if you "
+             "do not want a 404 error.",
     )
 
     @api.multi
@@ -40,6 +52,21 @@ class WebsiteSeoRedirection(models.Model):
     @api.constrains("destination")
     def _check_destination(self):
         self._url_format_check("destination")
+
+    @api.multi
+    @api.constrains("origin", "destination")
+    def _check_not_recursive(self):
+        """Avoid infinite loops."""
+        for redirection in self:
+            origins = {redirection.origin}
+            while redirection:
+                redirection = self.search([
+                    ("origin", "=", redirection.destination),
+                ])
+                if redirection.origin in origins:
+                    raise ValidationError(
+                        _("Recursive redirection is forbidden."))
+                origins.add(redirection.origin)
 
     @api.multi
     def _url_format_check(self, field_name):
@@ -65,7 +92,8 @@ class WebsiteSeoRedirection(models.Model):
             Destination path to get to a controller.
 
         :raise NoOriginError:
-            When no original URL is found.
+            When no original URL is found, or the found URL is not marked with
+            :attr:`relocate_controller`.
 
         :return str:
             Returns the original path (e.g. ``/page/example``) if
@@ -73,7 +101,10 @@ class WebsiteSeoRedirection(models.Model):
             redirections, or :attr:`redirected_path` itself otherwise.
         """
         path = redirected_path or request.httprequest.path
-        redirection = self.search([("destination", "=", path)])
+        redirection = self.search([
+            ("destination", "=", path),
+            ("relocate_controller", "=", True),
+        ])
         if not redirection.origin:
             raise NoOriginError(_("No origin found for this redirection."))
         return redirection.origin
@@ -118,7 +149,8 @@ class WebsiteSeoRedirection(models.Model):
             raise NoRedirectionError(_("Duplicated redirection."))
 
         # Add language prefix to URL
-        if website.default_lang_code != request.lang:
+        if (website.default_lang_code != request.lang and
+                request.lang in website.language_ids.mapped("code")):
             destination = u"/{}{}".format(request.lang, destination)
 
         # Redirect to the SEO URL
@@ -127,3 +159,32 @@ class WebsiteSeoRedirection(models.Model):
             dict(request.httprequest.args),
             True,
             code=code)
+
+    @api.model
+    def smart_add(self, origin, destination):
+        """Add or update redirection only if needed.
+
+        :param str origin:
+            The original URL.
+
+        :param str destination:
+            The new redirected URL.
+        """
+        if origin == destination:
+            return
+        records = self.search([
+            "|", ("origin", "=", origin),
+            ("destination", "in", [origin, destination]),
+        ])
+        if records:
+            for record in records:
+                try:
+                    with self.env.cr.savepoint():
+                        record.destination = destination
+                except (ValidationError, IntegrityError):
+                    record.unlink()
+        else:
+            self.create({
+                "origin": origin,
+                "destination": destination,
+            })

--- a/website_seo_redirection/static/src/js/website_seo.js
+++ b/website_seo_redirection/static/src/js/website_seo.js
@@ -1,0 +1,39 @@
+/* © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
+(function () {
+    "use strict";
+    var website = openerp.website;
+    website.add_template_file(
+        '/website_seo_redirection/static/src/xml/website_seo.xml');
+
+    website.seo.Configurator.include({
+        start: function () {
+            this.$seo_redirection = this.$el.find(
+                "#js_website_seo_redirection");
+            this.$seo_redirection.val(
+                document.location.pathname
+            );
+            return this._super();
+        },
+        saveMetaData: function (data) {
+            return $.when(this.update_seo_redirection(), this._super(data))
+                .done($.proxy(this.redirect_if_required, this));
+        },
+        update_seo_redirection: function () {
+            var newurl = this.$seo_redirection.val();
+            if (newurl === document.location.pathname) {
+                return $.Deferred().resolve("no-reload");
+            }
+            return website.session.model("website.seo.redirection").call(
+                "smart_add",
+                [document.location.pathname, newurl, website.get_context()]
+            );
+        },
+        redirect_if_required: function (result) {
+            if (result != "no-reload") {
+                document.location =
+                    this.$seo_redirection.val() + document.location.search;
+            }
+        },
+    });
+})();

--- a/website_seo_redirection/static/src/js/website_seo.js
+++ b/website_seo_redirection/static/src/js/website_seo.js
@@ -1,19 +1,25 @@
 /* © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
-(function () {
+odoo.define('website_seo_redirection.website_seo', function(require) {
     "use strict";
-    var website = openerp.website;
-    website.add_template_file(
-        '/website_seo_redirection/static/src/xml/website_seo.xml');
+    var ajax = require("web.ajax");
+    var base = require("web_editor.base");
+    var core = require("web.core");
+    var seo = require("website.seo");
+    var session = require("web.session");
+    var $ = require("$");
 
-    website.seo.Configurator.include({
+    seo.Configurator.include({
         start: function () {
+            ajax.loadXML(
+                '/website_seo_redirection/static/src/xml/website_seo.xml',
+                core.qweb
+            ).done($.proxy(this._super, this));
             this.$seo_redirection = this.$el.find(
                 "#js_website_seo_redirection");
             this.$seo_redirection.val(
                 document.location.pathname
             );
-            return this._super();
         },
         saveMetaData: function (data) {
             return $.when(this.update_seo_redirection(), this._super(data))
@@ -24,9 +30,9 @@
             if (newurl === document.location.pathname) {
                 return $.Deferred().resolve("no-reload");
             }
-            return website.session.model("website.seo.redirection").call(
+            return session.model("website.seo.redirection").call(
                 "smart_add",
-                [document.location.pathname, newurl, website.get_context()]
+                [document.location.pathname, newurl, base.get_context()]
             );
         },
         redirect_if_required: function (result) {
@@ -36,4 +42,4 @@
             }
         },
     });
-})();
+});

--- a/website_seo_redirection/static/src/js/website_seo_redirection.tour.js
+++ b/website_seo_redirection/static/src/js/website_seo_redirection.tour.js
@@ -1,12 +1,10 @@
 /* © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
-
-
 odoo.define('website_seo_redirection.tour', function(require) {
     'use strict';
-    
+
     var Tour = require('web.Tour');
-    
+
     Tour.register({
         id: "website_seo_redirection",
         name: "Check SEO redirections functionality",
@@ -15,28 +13,28 @@ odoo.define('website_seo_redirection.tour', function(require) {
         steps: [
             {
                 title: "Open SEO menu",
-                waitFor: "a>span:contains('SEO Sample')",
-                element: "a>span:contains('SEO Sample')",
+                waitFor: "a:contains('SEO Sample')",
+                element: "a:contains('SEO Sample')",
             },
             {
                 title: "Go to SEO sample page in original URL",
-                waitFor: "a>span:contains('Original URL')",
-                element: "a>span:contains('Original URL')",
+                waitFor: "a:contains('Original URL')",
+                element: "a:contains('Original URL')",
             },
             {
                 title: "Page reached, back to home",
                 waitFor: "#origin,#destination",
-                element: "a>span:contains('Home')",
+                element: "a:contains('Home')",
             },
             {
                 title: "Open SEO menu",
-                waitFor: "html[data-view-xmlid='website.homepage']",
-                element: "a>span:contains('SEO Sample')",
+                waitFor: "meta[property='og:title'][content='Homepage']",
+                element: "a:contains('SEO Sample')",
             },
             {
                 title: "Go to SEO sample page in destination URL",
-                waitFor: "a>span:contains('Redirected URL')",
-                element: "a>span:contains('Redirected URL')",
+                waitFor: "a:contains('Redirected URL')",
+                element: "a:contains('Redirected URL')",
             },
             {
                 title: "Page reached",

--- a/website_seo_redirection/static/src/xml/website_seo.xml
+++ b/website_seo_redirection/static/src/xml/website_seo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+<templates>
+    <t t-extend="website.seo_configuration">
+        <t t-jquery=".modal-body" t-operation="append">
+            <section>
+                <h3 class="page-header">
+                    Change the URL
+                </h3>
+                <div class="form-horizontal">
+                    <div class="panel panel-warning">
+                        <div class="panel-heading">
+                            BEWARE!
+                        </div>
+                        <div class="panel-body">
+                            If you need a special URL for this page, you can set it here, but if you set some URL that is already in use, could be interferring with other page and bad things could happen...
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="control-label col-lg-2"
+                               for="js_website_seo_redirection">
+                            Destination URL:
+                        </label>
+                        <div class="col-lg-8">
+                            <input
+                                id="js_website_seo_redirection"
+                                type="url"
+                                class="form-control"
+                                name="destination"
+                                title="URL without domain name, all lower case, hyphenated."
+                                placeholder="E.g.: /some/good-url"
+                                pattern="^/[a-z0-9/-]+$"/>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </t>
+    </t>
+</templates>

--- a/website_seo_redirection/tests/__init__.py
+++ b/website_seo_redirection/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
-from . import test_model_website_seo_redirection, test_ui
+from . import test_model_website_seo_redirection
+from . import test_model_website
+from . import test_ui

--- a/website_seo_redirection/tests/test_model_website.py
+++ b/website_seo_redirection/tests/test_model_website.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import json
+import logging
+from urllib2 import BaseHandler
+
+from openerp.tests.common import HttpCase
+_logger = logging.getLogger(__name__)
+
+
+# HACK http://stackoverflow.com/a/39248995/1468388
+class ChangeTypeProcessor(BaseHandler):
+    def http_request(self, req):
+        req.unredirected_hdrs["Content-type"] = "application/json"
+        return req
+
+
+class WebsiteCase(HttpCase):
+    def search_page(self, query):
+        """Perform a page search using JSON-RPC.
+
+        You need all this stuff to get a bound request.
+        """
+        self.authenticate("admin", "admin")
+        self.opener.add_handler(ChangeTypeProcessor())
+        params = {
+            "id": None,
+            "jsonrpc": "2.0",
+            "method": "call",
+            "params": {
+                "model": "website",
+                "method": "search_pages",
+                "args": [self.env["website"].get_current_website().id, query],
+            }
+        }
+        response = json.load(
+            self.url_open("/web/dataset/call", json.dumps(params)))
+        _logger.info("JSON Response:\n%s", response)
+        result = [page["loc"] for page in response["result"]]
+        _logger.info("URLs found:\n%s", result)
+        return result
+
+    def test_url_found_no_query(self):
+        """``/seo/sample`` should be found."""
+        found = self.search_page("")
+        self.assertIn("/seo/sample", found)
+        self.assertIn("/seo/sample/no-relocate", found)
+        self.assertIn("/page/website_seo_redirection.sample_page", found)
+        self.assertEqual(len(found), len(set(found)))
+
+    def test_url_found_queried_good(self):
+        """``/seo/sample`` should be found."""
+        found = self.search_page("sample")
+        self.assertIn("/seo/sample", found)
+        self.assertIn("/seo/sample/no-relocate", found)
+        self.assertIn("/page/website_seo_redirection.sample_page", found)
+        self.assertEqual(len(found), len(set(found)))
+
+    def test_url_found_queried_bad(self):
+        """``/seo/sample`` should not be found."""
+        found = self.search_page("trololo")
+        self.assertNotIn("/seo/sample", found)
+        self.assertNotIn("/seo/sample/no-relocate", found)
+        self.assertNotIn("/page/website_seo_redirection.sample_page", found)
+        self.assertEqual(len(found), len(set(found)))

--- a/website_seo_redirection/tests/test_model_website.py
+++ b/website_seo_redirection/tests/test_model_website.py
@@ -31,7 +31,10 @@ class WebsiteCase(HttpCase):
             "params": {
                 "model": "website",
                 "method": "search_pages",
-                "args": [self.env["website"].get_current_website().id, query],
+                "args": [
+                    self.env["website"]._get_current_website_id("localhost"),
+                    query,
+                ],
             }
         }
         response = json.load(

--- a/website_seo_redirection/tests/test_model_website_seo_redirection.py
+++ b/website_seo_redirection/tests/test_model_website_seo_redirection.py
@@ -2,6 +2,8 @@
 # © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from psycopg2 import IntegrityError
+
 from openerp.exceptions import ValidationError
 from openerp.tests.common import TransactionCase
 
@@ -17,6 +19,22 @@ class WebsiteSeoRedirectionCase(TransactionCase):
             "/test&other",
             "/test#anchor",
         }
+        self.ab = self.wsr.create({
+            "origin": "/a",
+            "destination": "/b",
+        })
+        self.cd = self.wsr.create({
+            "origin": "/c",
+            "destination": "/d",
+        })
+        self.de = self.wsr.create({
+            "origin": "/d",
+            "destination": "/e",
+        })
+        self.fa = self.wsr.create({
+            "origin": "/f",
+            "destination": "/a",
+        })
 
     def test_bad_origin(self):
         """Cannot enter a malformed origin URL."""
@@ -40,7 +58,7 @@ class WebsiteSeoRedirectionCase(TransactionCase):
 
     def test_equal_origin_redirection(self):
         """Cannot create a redirection to itself."""
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(IntegrityError):
             self.wsr.create({
                 "origin": "/same-url",
                 "destination": "/same-url",
@@ -62,3 +80,62 @@ class WebsiteSeoRedirectionCase(TransactionCase):
 
         # Search by whatever, return itself
         self.assertEqual("/page/whatever", "/page/whatever")
+
+    def test_no_recursive_first(self):
+        """Recursive redirections are forbidden."""
+        with self.assertRaises(ValidationError):
+            self.wsr.create({
+                "origin": "/e",
+                "destination": "/c",
+            })
+
+    def test_smart_add_modify_by_origin(self):
+        """:meth:`~.smart_add` replaces destination when origin is the same."""
+        self.wsr.smart_add("/a", "/c")
+        self.assertEqual(self.ab.origin, "/a")
+        self.assertEqual(self.ab.destination, "/c")
+        self.assertEqual(self.cd.origin, "/c")
+        self.assertEqual(self.cd.destination, "/d")
+        self.assertEqual(self.de.origin, "/d")
+        self.assertEqual(self.de.destination, "/e")
+        self.assertEqual(self.fa.origin, "/f")
+        self.assertEqual(self.fa.destination, "/c")
+
+    def test_smart_add_modify_by_destination(self):
+        """:meth:`~.smart_add` replaces destination when it is the same."""
+        self.wsr.smart_add("/d", "/e")
+        self.assertEqual(self.ab.origin, "/a")
+        self.assertEqual(self.ab.destination, "/b")
+        self.assertEqual(self.cd.origin, "/c")
+        self.assertEqual(self.cd.destination, "/e")
+        self.assertEqual(self.de.origin, "/d")
+        self.assertEqual(self.de.destination, "/e")
+        self.assertEqual(self.fa.origin, "/f")
+        self.assertEqual(self.fa.destination, "/a")
+
+    def test_smart_add_unlink_recursive(self):
+        """:meth:`~.smart_add` unlinks redirection when it is recursive."""
+        self.wsr.smart_add("/d", "/c")
+        self.assertEqual(self.ab.origin, "/a")
+        self.assertEqual(self.ab.destination, "/b")
+        self.assertFalse(self.cd.exists())
+        self.assertEqual(self.de.origin, "/d")
+        self.assertEqual(self.de.destination, "/c")
+        self.assertEqual(self.fa.origin, "/f")
+        self.assertEqual(self.fa.destination, "/a")
+
+    def test_smart_add_create(self):
+        """:meth:`~.smart_add` creates a redirection."""
+        self.wsr.smart_add("/g", "/h")
+        self.assertEqual(self.ab.origin, "/a")
+        self.assertEqual(self.ab.destination, "/b")
+        self.assertEqual(self.cd.origin, "/c")
+        self.assertEqual(self.cd.destination, "/d")
+        self.assertEqual(self.de.origin, "/d")
+        self.assertEqual(self.de.destination, "/e")
+        self.assertEqual(self.fa.origin, "/f")
+        self.assertEqual(self.fa.destination, "/a")
+        self.assertTrue(self.wsr.search([
+            ("origin", "=", "/g"),
+            ("destination", "=", "/h"),
+        ]))

--- a/website_seo_redirection/tests/test_ui.py
+++ b/website_seo_redirection/tests/test_ui.py
@@ -8,8 +8,9 @@ from openerp.tests.common import HttpCase
 class UICase(HttpCase):
     def test_admin_tour_en_US(self):
         """Redirections work with default language."""
+        tour = "odoo.__DEBUG__.services['web.Tour']"
         self.phantom_js(
             "/en_US",
-            "openerp.Tour.run('website_seo_redirection')",
-            "openerp.Tour.tours.website_seo_redirection",
+            tour + ".run('website_seo_redirection')",
+            tour + ".tours.website_seo_redirection",
             "admin")

--- a/website_seo_redirection/views/assets.xml
+++ b/website_seo_redirection/views/assets.xml
@@ -8,6 +8,8 @@
     <xpath expr=".">
         <script type="text/javascript"
                 src="/website_seo_redirection/static/src/js/website_seo_redirection.tour.js"/>
+        <script type="text/javascript"
+                src="/website_seo_redirection/static/src/js/website_seo.js"/>
     </xpath>
 </template>
 

--- a/website_seo_redirection/views/website_seo_redirection_view.xml
+++ b/website_seo_redirection/views/website_seo_redirection_view.xml
@@ -13,6 +13,7 @@
                 <group>
                     <field name="origin"/>
                     <field name="destination"/>
+                    <field name="relocate_controller"/>
                 </group>
             </sheet>
         </form>
@@ -26,6 +27,7 @@
         <tree editable="top">
             <field name="origin"/>
             <field name="destination"/>
+            <field name="relocate_controller"/>
         </tree>
     </field>
 </record>


### PR DESCRIPTION
Forward #246 and #255 to v9.
- Fix a bug that was redirecting to disabled languages if the user's browser was in an installed language that was disabled for the website.
- Allow to have several origins for a destination.
- Disallow recursive redirections.
- Add both original and redirected URLs to web editor link search.
- Cannot have a redirection to yourself, now as a SQL constraint.
- Rename "Redirected URL" to "Destination URL" (seems more self-explicative).
- Add support for redirections that don't replace the controller (AKA shortcuts).
- Allow to choose a page URL from the "Promote" menu.
- Fix some styling issues, including `"use strict"` outside the function block.
- Tests, tests, tests (man, those JSONRPC ones were hard).

@Tecnativa
