### PR TITLE
[FIX][website_seo_redirection] Use 301 redirections.

### DIFF
--- a/website_seo_redirection/models/website_seo_redirection.py
+++ b/website_seo_redirection/models/website_seo_redirection.py
@@ -157,7 +157,6 @@ class WebsiteSeoRedirection(models.Model):
         return local_redirect(
             destination,
             dict(request.httprequest.args),
-            True,
             code=code)
 
     @api.model


### PR DESCRIPTION
[The recommended redirection method for not losing SEO is with 301](https://support.google.com/webmasters/answer/93633).

Currently, it was returning a 200 response with a JS redirection:

```
HTTP/1.0 200 OK
...
<html><head><script>window.location = '/new-url' + location.hash;</script></head></html>
```

Now, it returns a real 301 response, best for SEO purposes:

```
HTTP/1.0 301 MOVED PERMANENTLY
Location: http://localhost/new-url
...
```

... but you will lose the chance to keep `#hash` in the URL. Shameful, but this option fits better with this module's purpose.

@Tecnativa
