### PR TITLE
[8.0][IMP][website_canonical_url] Safer, prefer root, relative paths

### DIFF
--- a/website_canonical_url/README.rst
+++ b/website_canonical_url/README.rst
@@ -27,6 +27,7 @@ Contributors
 
 * Thomas Rehn <thomas.rehn@initos.com>
 * Rami Alwafaie <rami.alwafaie@initos.com>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/website_canonical_url/__openerp__.py
+++ b/website_canonical_url/__openerp__.py
@@ -4,13 +4,11 @@
 
 {
     'name': "Website Canoncial URL",
-    'summary': """
-        Canonical URL in Website Headers
-        """,
-    'author': "initOS GmbH, Odoo Community Association (OCA)",
+    'summary': "Canonical URL in Website Headers",
+    'author': "initOS GmbH, Tecnativa, Odoo Community Association (OCA)",
     'website': "http://www.initos.com",
     'category': 'Website',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.1.0',
     'license': 'AGPL-3',
     'depends': [
         'website',

--- a/website_canonical_url/models/website.py
+++ b/website_canonical_url/models/website.py
@@ -15,12 +15,12 @@ class website(models.Model):
         canonical_url = None
         if req is None:
             req = request
-        if req and req.httprequest.base_url:
+        if req and req.httprequest.path:
             lang = self.env.lang
             if lang == request.website.default_lang_code:
-                canonical_url = req.httprequest.base_url
+                canonical_url = req.httprequest.path
             else:
-                url_parts = urlparse(req.httprequest.base_url)
+                url_parts = urlparse(req.httprequest.path)
                 url_parts = list(url_parts)
                 # change the path of the url
                 url_parts[2] = lang + url_parts[2]

--- a/website_canonical_url/models/website.py
+++ b/website_canonical_url/models/website.py
@@ -16,7 +16,7 @@ class website(models.Model):
         if req is None:
             req = request
         if req and req.httprequest.base_url:
-            lang = self._context['lang']
+            lang = self.env.lang
             if lang == request.website.default_lang_code:
                 canonical_url = req.httprequest.base_url
             else:

--- a/website_canonical_url/models/website.py
+++ b/website_canonical_url/models/website.py
@@ -25,4 +25,11 @@ class website(models.Model):
                 # change the path of the url
                 url_parts[2] = lang + url_parts[2]
                 canonical_url = urlunparse(url_parts)
+        # Special case for rerouted requests to root path
+        try:
+            if (canonical_url.startswith("/page/") and
+                    self.menu_id.child_id[0].url == canonical_url):
+                canonical_url = "/"
+        except:
+            pass
         return canonical_url


### PR DESCRIPTION
This patch makes this addon more SEO-friendly:
- Includes a safety fix to avoid possible `KeyError` when no lang in context (could this ever happen? not sure, but preventing is easier).
- Uses relative paths everywhere, so this works fine under any setup (HTTPS proxies, anyone?).
- In case you visit `/`, and that gets rerouted to your homepage (`/page/homepage` by default), then we canonicalize `/` instead. This is better because it fits more what the user would type in the URL bar, and removes stop words from the indexed URL.

@Tecnativa
