### PR TITLE
[MIG][10.0] website_field_autocomplete_related

### DIFF
--- a/website_field_autocomplete_related/README.rst
+++ b/website_field_autocomplete_related/README.rst
@@ -88,7 +88,7 @@ Following is a breakdown of the attributes and functions provided:
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/186/9.0
+   :target: https://runbot.odoo-community.org/runbot/186/10.0
 
 
 Known Issues / Road Map

--- a/website_field_autocomplete_related/README.rst
+++ b/website_field_autocomplete_related/README.rst
@@ -41,16 +41,6 @@ Following is an example:
            data-model="res.partner"
            />
 
-    <label for="company">Company</label>
-    <input type="text"
-           name="company"
-           class="js_website_autocomplete"
-           data-query-field="name"
-           data-relate-recv="res_partner"
-           data-relate-send="_"
-           data-model="res.company"
-           />
-
     <label for="name">Phone</label>
     <input type="text"
            name="phone"

--- a/website_field_autocomplete_related/README.rst
+++ b/website_field_autocomplete_related/README.rst
@@ -1,0 +1,129 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================
+Website Field AutoComplete Related
+==================================
+
+Extends Website Autocomplete field to allow for related fields, for example
+a form that automatically completes based on search results.
+
+Usage
+=====
+
+To use this module, you would follow the instructions provided in
+``website_field_autocomplete``.
+
+The only difference is that you would create multiple auto complete
+fields, then utilize the ``data-relate-recv`` attribute to link the
+fields' data & searches together.
+
+If you would like to activate the relation on a non-autocomplete element,
+you also need to add the ``data-query-field`` attribute or match the name of
+the element to the name of the column.
+
+If you would like to send data to a different Relation Group, you can use the
+``data-relate-send`` attribute. If you utilize this attribute, you will likely
+also need ``data-recv-field`` which will select the field that should be
+received when it is updated via its receive group.
+
+Following is an example:
+
+.. code:: xml
+
+    <label for="name">Name</label>
+    <input type="text"
+           name="name"
+           class="js_website_autocomplete"
+           data-query-field="name"
+           data-relate-recv="res_partner"
+           data-model="res.partner"
+           />
+
+    <label for="company">Company</label>
+    <input type="text"
+           name="company"
+           class="js_website_autocomplete"
+           data-query-field="name"
+           data-relate-recv="res_partner"
+           data-relate-send="_"
+           data-model="res.company"
+           />
+
+    <label for="name">Phone</label>
+    <input type="text"
+           name="phone"
+           class="js_website_autocomplete"
+           data-query-field="phone"
+           data-relate-recv="res_partner"
+           data-model="res.partner"
+           />
+
+    <label for="name">Street</label>
+    <input type="text"
+           name="company"
+           data-query-field="street"
+           data-relate-recv="res_partner"
+           />
+
+    <label for="name">Street 2</label>
+    <input type="text"
+           name="street2"
+           data-relate-recv="res_partner"
+           />
+
+Following is a breakdown of the attributes and functions provided:
+
++--------------------+-----------------------------------------------------+---------------+----------+
+|  Attribute         |  Description                                        |  Default      | Required |
++====================+=====================================================+===============+==========+
+| data-relate-recv   | Receive data updated from fields of this group      |               | False    |
++--------------------+-----------------------------------------------------+---------------+----------+
+| data-relate-send   | Send data to fields with this group name            | relate-recv   | False    |
++--------------------+-----------------------------------------------------+---------------+----------+
+| data-recv-field    | Column name to receive data on (from res model)     |  query-field  | False    |
++--------------------+-----------------------------------------------------+---------------+----------+
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/186/9.0
+
+
+Known Issues / Road Map
+=======================
+
+* Eliminate need for second query in ``main.Website()._get_autocomplete_data``
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/website/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_field_autocomplete_related/__init__.py
+++ b/website_field_autocomplete_related/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import controllers

--- a/website_field_autocomplete_related/__manifest__.py
+++ b/website_field_autocomplete_related/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Website Field AutoComplete Related",
     "summary": 'Extends website autocomplete field to allow updates of '
                'related fields.',
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "category": "Website",
     "website": "https://laslabs.com/",
     "author": "LasLabs, Odoo Community Association (OCA)",

--- a/website_field_autocomplete_related/__openerp__.py
+++ b/website_field_autocomplete_related/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Website Field AutoComplete Related",
+    "summary": 'Extends website autocomplete field to allow updates of '
+               'related fields.',
+    "version": "9.0.1.0.0",
+    "category": "Website",
+    "website": "https://laslabs.com/",
+    "author": "LasLabs, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website_field_autocomplete",
+    ],
+    "data": [
+        'views/assets.xml',
+    ],
+    'demo': [
+        'demo/field_autocomplete_demo.xml',
+    ]
+}

--- a/website_field_autocomplete_related/controllers/__init__.py
+++ b/website_field_autocomplete_related/controllers/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import main

--- a/website_field_autocomplete_related/controllers/main.py
+++ b/website_field_autocomplete_related/controllers/main.py
@@ -2,8 +2,8 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp.http import request
-from openerp.addons.website_field_autocomplete.controllers.main import Website
+from odoo.http import request
+from odoo.addons.website_field_autocomplete.controllers.main import Website
 
 
 class WebsiteAutocomplete(Website):

--- a/website_field_autocomplete_related/controllers/main.py
+++ b/website_field_autocomplete_related/controllers/main.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.http import request
+from openerp.addons.website_field_autocomplete.controllers.main import Website
+
+
+class WebsiteAutocomplete(Website):
+
+    def _get_autocomplete_data(self, model, domain, fields, limit=None):
+        """ Perform recursive search_reads to get all related data """
+        res = super(WebsiteAutocomplete, self)._get_autocomplete_data(
+            model, domain, fields, limit,
+        )
+        self.record_ids = request.env[model].search(domain)
+        for field in fields:
+            if '.' in field:
+                for rec_id in self.record_ids:
+                    res[rec_id.id][field] = self._get_relation_data(
+                        rec_id, field,
+                    )
+        return res
+
+    def _get_relation_data(self, record_id, field_name):
+        """ Iterate dot notated fields and inject data into object """
+        obj = record_id
+        for field_part in field_name.split('.'):
+            obj = getattr(obj, field_part, None)
+            if obj is None:
+                return obj
+        return obj

--- a/website_field_autocomplete_related/controllers/main.py
+++ b/website_field_autocomplete_related/controllers/main.py
@@ -14,12 +14,11 @@ class WebsiteAutocomplete(Website):
             model, domain, fields, limit,
         )
         self.record_ids = request.env[model].search(domain)
-        for field in fields:
-            if '.' in field:
-                for rec_id in self.record_ids:
-                    res[rec_id.id][field] = self._get_relation_data(
-                        rec_id, field,
-                    )
+        for field in filter(lambda f: '.' in f, fields):
+            for rec_id in self.record_ids:
+                res[rec_id.id][field] = self._get_relation_data(
+                    rec_id, field,
+                )
         return res
 
     def _get_relation_data(self, record_id, field_name):

--- a/website_field_autocomplete_related/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete_related/demo/field_autocomplete_demo.xml
@@ -10,32 +10,35 @@
         <xpath expr="//div[@class='row']" position="after">
             <div class="row">
                 <h1>Partner Autocomplete Related:</h1>
+                <h4>The below autocomplete implementation links multiple fields to the same autocomplete logic.</h4>
                 <div class="row">
-                    <label for="name">Name</label>
+                    <label for="name">URL</label>
+                    <input type="text"
+                           name="url"
+                           class="js_website_autocomplete"
+                           data-query-field="url"
+                           data-relate-recv="act_url"
+                           data-model="ir.actions.act_url"
+                           />
+                </div>
+                <div class="row">
+                    <label for="phone">Name</label>
                     <input type="text"
                            name="name"
                            class="js_website_autocomplete"
                            data-query-field="name"
-                           data-relate-recv="res_partner"
-                           data-model="res.partner"
+                           data-relate-recv="act_url"
+                           data-model="ir.actions.act_url"
                            />
                 </div>
                 <div class="row">
-                    <label for="phone">Phone</label>
+                    <label for="street">Target</label>
                     <input type="text"
-                           name="phone"
+                           name="target"
                            class="js_website_autocomplete"
-                           data-query-field="phone"
-                           data-relate-recv="res_partner"
-                           data-model="res.partner"
-                           />
-                </div>
-                <div class="row">
-                    <label for="street">Street</label>
-                    <input type="text"
-                           name="street"
-                           data-query-field="street"
-                           data-relate-recv="res_partner"
+                           data-query-field="target"
+                           data-relate-recv="act_url"
+                           data-model="ir.actions.act_url"
                            />
                 </div>
             </div>

--- a/website_field_autocomplete_related/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete_related/demo/field_autocomplete_demo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    @license AGPL-3 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    <template id="field_autocomplete_demo" name="Field Autocomplete Demo" inherit_id="website_field_autocomplete.field_autocomplete_demo">
+        <xpath expr="//div[@class='row']" position="after">
+            <div class="row">
+                <h1>Partner Autocomplete Related:</h1>
+                <div class="row">
+                    <label for="name">Name</label>
+                    <input type="text"
+                           name="name"
+                           class="js_website_autocomplete"
+                           data-query-field="name"
+                           data-relate-recv="res_partner"
+                           data-model="res.partner"
+                           />
+                </div>
+                <div class="row">
+                    <label for="company">Company</label>
+                    <input type="text"
+                           name="company"
+                           class="js_website_autocomplete"
+                           data-query-field="name"
+                           data-recv-field="company_id.name"
+                           data-relate-recv="res_partner"
+                           data-relate-send="_"
+                           data-model="res.company"
+                           />
+                </div>
+                <div class="row">
+                    <label for="phone">Phone</label>
+                    <input type="text"
+                           name="phone"
+                           class="js_website_autocomplete"
+                           data-query-field="phone"
+                           data-relate-recv="res_partner"
+                           data-model="res.partner"
+                           />
+                </div>
+                <div class="row">
+                    <label for="street">Street</label>
+                    <input type="text"
+                           name="street"
+                           data-query-field="street"
+                           data-relate-recv="res_partner"
+                           />
+                </div>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/website_field_autocomplete_related/demo/field_autocomplete_demo.xml
+++ b/website_field_autocomplete_related/demo/field_autocomplete_demo.xml
@@ -21,18 +21,6 @@
                            />
                 </div>
                 <div class="row">
-                    <label for="company">Company</label>
-                    <input type="text"
-                           name="company"
-                           class="js_website_autocomplete"
-                           data-query-field="name"
-                           data-recv-field="company_id.name"
-                           data-relate-recv="res_partner"
-                           data-relate-send="_"
-                           data-model="res.company"
-                           />
-                </div>
-                <div class="row">
                     <label for="phone">Phone</label>
                     <input type="text"
                            name="phone"

--- a/website_field_autocomplete_related/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete_related/static/src/js/field_autocomplete.js
@@ -48,25 +48,26 @@ odoo.define('website_field_autocomplete_related.field_autocomplete', function(re
     start: function() {
       this._super();
       var self = this;
+      var relationGroup = this.$target.data('relate-send') || this.$target.data('relate-recv');
+      if (!relationGroup) {
+        return
+      }
       if (this.valueField != 'id') {
         this.valueField = 'id';
         this.fields.push('id');
       }
-      var relationGroup = this.$target.data('relate-send') || this.$target.data('relate-recv');
-      if (relationGroup) {
-        this.$related = $('*[data-relate-recv="' + relationGroup + '"]')
-          .add(this.$target);
-        this.$related.each(function() {
-          var $this = $(this);
-          var field = $this.data('recv-field') || $this.data('query-field');
-          if (field){
-            self.fields.push(field);
-          } 
-        });
-        this.$target.on('autocompleteselect', function(event, ui) {
-          self.autocompleteselect(event, ui);
-        });
-      }
+      this.$related = $('*[data-relate-recv="' + relationGroup + '"]')
+        .add(this.$target);
+      this.$related.each(function() {
+        var $this = $(this);
+        var field = $this.data('recv-field') || $this.data('query-field');
+        if (field){
+          self.fields.push(field);
+        }
+      });
+      this.$target.on('autocompleteselect', function(event, ui) {
+        self.autocompleteselect(event, ui);
+      });
     },
     
   });

--- a/website_field_autocomplete_related/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete_related/static/src/js/field_autocomplete.js
@@ -1,0 +1,75 @@
+/* Copyright 2016 LasLabs Inc.
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ */
+
+odoo.define('website_field_autocomplete_related.field_autocomplete', function(require){
+  "use strict";
+
+  var snippet_animation = require('web_editor.snippets.animation');
+  var $ = require('$');
+
+  snippet_animation.registry.field_autocomplete = snippet_animation.registry.field_autocomplete.extend({
+
+    $related: false,
+    data: {},
+
+    autocomplete: function(request, response) {
+      var self = this;
+      return this._super(request, response).then(function(records) {
+        self.data = {};
+        for (var i = 0, len = records.length; i < len; i++) {
+          var record = records[i];
+          self.data[record.id] = record;
+        }
+        return records;
+      });
+    },
+    
+    /* Update text in related fields
+     * @param event Event obj
+     * @param ui obj {'value': str, 'label': str}
+     */
+    autocompleteselect: function(event, ui) {
+      event.preventDefault();
+      if (!this.$related) {
+        return;
+      }
+      var record = this.data[ui.item.value];
+      this.$related.each(function(){
+        var $this = $(this);
+        var recvField = $this.data('recv-field') || $this.data('query-field') || 'name';
+        if (['checkbox', 'radio'].indexOf(this.type) != -1) {
+          $(this).attr('checked', record[recvField]);
+        } else {
+          $(this).val(record[recvField] || '');
+        }
+      });
+    },
+    
+    start: function() {
+      this._super();
+      var self = this;
+      if (this.valueField != 'id') {
+        this.valueField = 'id';
+        this.fields.push('id');
+      }
+      var relationGroup = this.$target.data('relate-send') || this.$target.data('relate-recv');
+      if (relationGroup) {
+        this.$related = $('*[data-relate-recv="' + relationGroup + '"]')
+          .add(this.$target);
+        this.$related.each(function() {
+          var $this = $(this);
+          var field = $this.data('recv-field') || $this.data('query-field');
+          if (field){
+            self.fields.push(field);
+          } 
+        });
+        this.$target.on('autocompleteselect', function(event, ui) {
+          self.autocompleteselect(event, ui);
+        });
+      }
+    },
+    
+  });
+
+});

--- a/website_field_autocomplete_related/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete_related/static/src/js/field_autocomplete.js
@@ -6,7 +6,6 @@ odoo.define('website_field_autocomplete_related.field_autocomplete', function(re
   "use strict";
 
   var snippet_animation = require('web_editor.snippets.animation');
-  var $ = require('$');
 
   snippet_animation.registry.field_autocomplete = snippet_animation.registry.field_autocomplete.extend({
 

--- a/website_field_autocomplete_related/tests/__init__.py
+++ b/website_field_autocomplete_related/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_controller

--- a/website_field_autocomplete_related/tests/test_controller.py
+++ b/website_field_autocomplete_related/tests/test_controller.py
@@ -5,9 +5,9 @@
 import mock
 from contextlib import contextmanager
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 
-from openerp.addons.website_field_autocomplete_related.controllers import main
+from odoo.addons.website_field_autocomplete_related.controllers import main
 
 
 class TestController(TransactionCase):

--- a/website_field_autocomplete_related/tests/test_controller.py
+++ b/website_field_autocomplete_related/tests/test_controller.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# © 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+from contextlib import contextmanager
+
+from openerp.tests.common import TransactionCase
+
+from openerp.addons.website_field_autocomplete_related.controllers import main
+
+
+class TestController(TransactionCase):
+
+    def setUp(self):
+        super(TestController, self).setUp()
+        self.Controller = main.WebsiteAutocomplete
+        self.controller = self.Controller()
+        self.record = self.env.user
+        self.fields = [
+            'name', 'partner_id.name',
+        ]
+
+    @contextmanager
+    def mock_controller(self):
+        with mock.patch.object(main.Website, '_get_autocomplete_data') as mk:
+            with mock.patch.object(main, 'request') as request:
+                request.env[''].search.return_value = self.record
+                mk.return_value = {
+                    self.record.id: {
+                        'name': self.record.name,
+                    }
+                }
+                yield {
+                    'super': mk,
+                    'request': request,
+                }
+
+    def test_get_autocomplete_data_search(self):
+        """ It should call search w/ proper domain """
+        expect = [('name', '=', self.record.name)]
+        with self.mock_controller() as mk:
+            self.controller._get_autocomplete_data(
+                self.record._name, expect, self.fields, 10
+            )
+            mk['request'].env[''].search.assert_called_once_with(
+                expect
+            )
+
+    def test_get_autocomplete_data_return(self):
+        """ It should return dictionary w/ proper vals """
+        with self.mock_controller():
+            res = self.controller._get_autocomplete_data(
+                self.record._name, [], self.fields, 10
+            )
+            expect = {
+                self.record.id: {
+                    'name': self.record.name,
+                    'partner_id.name': self.record.partner_id.name,
+                },
+            }
+            self.assertDictEqual(expect, res)
+
+    def test_get_relational_data(self):
+        """ It should return proper field value """
+        with self.mock_controller():
+            res = self.controller._get_relation_data(
+                self.record, self.fields[1],
+            )
+            self.assertEqual(
+                self.record.partner_id.name,
+                res,
+            )

--- a/website_field_autocomplete_related/views/assets.xml
+++ b/website_field_autocomplete_related/views/assets.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    @license AGPL-3 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    <template id="assets_autocomplete_related" name="website_field_autocomplete_related Assets" inherit_id="website.assets_frontend">
+        <xpath expr="." position="inside">
+            <script src="/website_field_autocomplete_related/static/src/js/field_autocomplete.js" />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This is a forward port of #217. It's a vertical-medical website dependency, so is a blocker to my upgrades there - hence the need to port before the v9 is merged.
- Rename manifest file
- Bump version
- Change openerp namespace to odoo
- Remove jQuery require

Dependent on:
- [x] #269 
