### PR TITLE
[FIX] Fixing ssl break and redirect for multilanguage websites

### DIFF
--- a/website_form_recaptcha/controllers/main.py
+++ b/website_form_recaptcha/controllers/main.py
@@ -17,6 +17,7 @@ class WebsiteForm(http.Controller):
         auth='public',
         methods=['GET'],
         website=True,
+        multilang=False,
     )
     def recaptcha_public(self):
         return json.dumps({


### PR DESCRIPTION
This is a very similar case to the Odoo image retrieval in V8. Only in this case it's the retrieval of the recaptcha site key.

See commit here:
https://github.com/odoo/odoo/commit/40c35fb48ab8c4b73dc0b16654b4d7f16d4b945c

This could also be fixed with removing website=True kwarg but it may have other implications as Martin explained here:

https://github.com/odoo/odoo/pull/8515