### PR TITLE
[8.0][FIX]website_snippet_country_dropdown:Avoid sending the country code …

### DIFF
--- a/website_snippet_country_dropdown/static/src/js/website_snippet_country_dropdown.js
+++ b/website_snippet_country_dropdown/static/src/js/website_snippet_country_dropdown.js
@@ -20,6 +20,11 @@
             this.$flag_selector.on('click', function(event) {
                 return self.set_value(event);
             });
+            $('form[action="/shop/confirm_order"]').on('submit', function(){
+                if(!this.no_country_field.value){
+                    this.vat.value = "";
+                }
+            });
             this.$no_country_field.change(function(event){
                 return self.join_value(self.$country_code_field.val(), this.value);
             });


### PR DESCRIPTION
…to the server when the vat is empty.

Currently it avoids leaving the vat field empty altrough it is optional.