### PR TITLE
[9.0][FIX][website_portal_contact] Use demo user instead of portal one for tests.

### DIFF
--- a/website_portal_contact/tests/test_ui.py
+++ b/website_portal_contact/tests/test_ui.py
@@ -6,6 +6,13 @@ from openerp.tests.common import HttpCase
 
 
 class UICase(HttpCase):
+    def setUp(self):
+        super(UICase, self).setUp()
+        with self.cursor() as cr:
+            env = self.env(cr)
+            # Need a demo user with portal permissions
+            env.ref("base.user_demo").groups_id = env.ref("base.group_portal")
+
     def test_contacts(self):
         """Test frontend tour."""
         self.phantom_js(
@@ -14,4 +21,4 @@ class UICase(HttpCase):
                  ".run('website_portal_contact', 'test', 'events')",
             ready="odoo.__DEBUG__.services['web.Tour']"
                   ".tours.website_portal_contact",
-            login="portal")
+            login="demo")


### PR DESCRIPTION
This fixes Travis for OCB build, by applying a workaround for https://github.com/odoo/odoo/pull/14859.

https://github.com/OCA/OCB/pull/575 introduced an incompatibility between OCB and Odoo builds, which results in having no portal user for tours.

@Tecnativa