### PR TITLE
[8.0] website_seo_redirection display internal error on multiple origin

### DIFF
--- a/website_seo_redirection/models/website_seo_redirection.py
+++ b/website_seo_redirection/models/website_seo_redirection.py
@@ -105,7 +105,9 @@ class WebsiteSeoRedirection(models.Model):
             ("destination", "=", path),
             ("relocate_controller", "=", True),
         ])
-        if not redirection.origin:
+        if len(redirection) > 1:
+            raise NoOriginError(_("Too many origin found for this redirection."))
+        elif not redirection.origin:
             raise NoOriginError(_("No origin found for this redirection."))
         return redirection.origin
 

--- a/website_seo_redirection/models/website_seo_redirection.py
+++ b/website_seo_redirection/models/website_seo_redirection.py
@@ -106,7 +106,7 @@ class WebsiteSeoRedirection(models.Model):
             ("relocate_controller", "=", True),
         ])
         if len(redirection) > 1:
-            raise NoOriginError(_("Too many origin found for this redirection."))
+            raise NoOriginError(_("Many origin found for this redirection."))
         elif not redirection.origin:
             raise NoOriginError(_("No origin found for this redirection."))
         return redirection.origin

--- a/website_seo_redirection/tests/test_model_website_seo_redirection.py
+++ b/website_seo_redirection/tests/test_model_website_seo_redirection.py
@@ -6,7 +6,7 @@ from psycopg2 import IntegrityError
 
 from openerp.exceptions import ValidationError
 from openerp.tests.common import TransactionCase
-from ..exceptions import NoOriginError, NoRedirectionError
+from ..exceptions import NoOriginError
 
 
 class WebsiteSeoRedirectionCase(TransactionCase):

--- a/website_seo_redirection/tests/test_model_website_seo_redirection.py
+++ b/website_seo_redirection/tests/test_model_website_seo_redirection.py
@@ -6,6 +6,7 @@ from psycopg2 import IntegrityError
 
 from openerp.exceptions import ValidationError
 from openerp.tests.common import TransactionCase
+from ..exceptions import NoOriginError, NoRedirectionError
 
 
 class WebsiteSeoRedirectionCase(TransactionCase):
@@ -80,6 +81,26 @@ class WebsiteSeoRedirectionCase(TransactionCase):
 
         # Search by whatever, return itself
         self.assertEqual("/page/whatever", "/page/whatever")
+
+    def test_ignore_multi_origin(self):
+        """Ignore origin if destination have multiple origin like:
+            /tinyerp -> /odoo
+            /openerp -> /odoo
+        """
+        r_tiny = self.wsr.create({
+            "origin": "/tinyerp",
+            "destination": "/odoo",
+        })
+        r_open = self.wsr.create({
+            "origin": "/openerp",
+            "destination": "/odoo",
+        })
+        # Search by origin, return itself
+        self.assertEqual(r_tiny.destination, r_open.destination)
+
+        # Nothing to do if destination have multiple origin
+        with self.assertRaises(NoOriginError):
+            self.wsr.find_origin(r_open.destination),
 
     def test_no_recursive_first(self):
         """Recursive redirections are forbidden."""


### PR DESCRIPTION
Hi 

When the same destination have multiple origin like:

- /tinyerp -> /odoo 
- /openerp -> /odoo

When visit /odoo we have an internal error (except_orm) and failed to display website properly

I have made a test to reproduce the error, and patch to fix this issue

Regards,
