### PR TITLE
[9.0][FIX][website_portal_purchase] Fix copyright header.

### DIFF
--- a/website_portal_purchase/static/src/sass/website_portal_purchase.sass
+++ b/website_portal_purchase/static/src/sass/website_portal_purchase.sass
@@ -1,7 +1,6 @@
-@charset "utf-8"
-/* (C) 2015-2016 Odoo S.A.
- * (C) 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
- * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+/*! Copyright 2015-2016 Odoo S.A.
+    Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 .supplier_orders_vertical_align
     display: flex


### PR DESCRIPTION
Sass requires consistent indentation even for multiline comments, so I add it here.
I take the time too to change (C) for Copyright (which actually has a legal meaning).
This should fix https://github.com/OCA/website/issues/304#issuecomment-270628689.

@Tecnativa