### PR TITLE
[FIX][IMP][website_event_register_free_with_sale] Store ticket type and allow multiple tickets

### DIFF
--- a/website_event_register_free/controllers/website_event.py
+++ b/website_event_register_free/controllers/website_event.py
@@ -48,13 +48,13 @@ class WebsiteEvent(website_event):
                 validate('tickets', force_check=True)):
             # if logged in, use that info
             registration_vals = reg_obj._prepare_registration(
-                event, post, http.request.env.user.id,
+                event.id, post, http.request.env.user.id,
                 partner=http.request.env.user.partner_id)
         if all(map(lambda f: validate(f, force_check=True),
                    ['name', 'email', 'tickets'])):
             # otherwise, create a simple registration
             registration_vals = reg_obj._prepare_registration(
-                event, post, http.request.env.user.id)
+                event.id, post, http.request.env.user.id)
         if registration_vals:
             registration = reg_obj.sudo().create(registration_vals)
             if registration.partner_id:

--- a/website_event_register_free/model/event_registration.py
+++ b/website_event_register_free/model/event_registration.py
@@ -24,11 +24,11 @@ from openerp import models, fields
 class EventRegistration(models.Model):
     _inherit = 'event.registration'
 
-    def _prepare_registration(self, event, post, user_id, partner=False):
+    def _prepare_registration(self, event_id, post, user_id, partner=False):
         return {
             'origin': 'Website',
             'nb_register': int(post['tickets']),
-            'event_id': event.id,
+            'event_id': event_id,
             'date_open': fields.Datetime.now(),
             'email': post.get('email') or partner and partner.email,
             'phone': post.get('phone') or partner and partner.phone,

--- a/website_event_register_free_with_sale/exceptions.py
+++ b/website_event_register_free_with_sale/exceptions.py
@@ -10,5 +10,5 @@ class NoNeedForSOError(exceptions.ValidationError):
 
     Useful when you want to register for free and there is nothing to invoice.
     """
-    def __init__(self, registration):
-        self.registration = registration
+    def __init__(self, registrations):
+        self.registrations = registrations


### PR DESCRIPTION
Previous implementation had these problems:

1. It did not store the ticket type along with the registration when it was a free one.
2. It did not allow to reserve multiple ticket types at once, tightly related to problem 1.

With this patch:

- `event.registration._prepare_registration()` is simplified because it does not require a recordset for the event.
- You can have several free tickets for the same event.
- You can reserve several free tickets along with several paid tickets in one step.
- The free ticket type is stored along with the reservation record.
- We only use 1 session key for all of this (`free_tickets`), which makes maintenance easier.

@Tecnativa