### PR TITLE
[FIX][website_snippet_anchor] Avoid TypeError.

### DIFF
--- a/website_snippet_anchor/static/src/js/website_snippet_anchor.js
+++ b/website_snippet_anchor/static/src/js/website_snippet_anchor.js
@@ -113,7 +113,7 @@ odoo.define('website_snippet_anchor.widgets', function (require) {
          */
         bind_data: function () {
             var url = this.element && this.element.getAttribute("href"),
-                url_parts = url.split("#", 2);
+                url_parts = url && url.split("#", 2) || "";
 
             // Trick this._super()
             if (url_parts.length > 1) {


### PR DESCRIPTION
We had this :bug::

1. Go to your website.
2. Press *Content > Edit menu*.
3. Press the pencil icon in any menu element.
4. Console logs: `TypeError: url is undefined`, and nothing happens in the UI.

Now it is fixed.

@Tecnativa