### PR TITLE
[FIX][website_cookie_notice] Fix mobile layout

### DIFF
--- a/website_cookie_notice/views/website.xml
+++ b/website_cookie_notice/views/website.xml
@@ -15,8 +15,8 @@
         class="container-fluid bg-warning cc-cookies">
         <div class="container">
             <div class="row">
-                <div class="col-xs-10">We use cookies in this website. Read about them in our <a href="/page/privacy">privacy policy</a>. To disable them, configure your browser properly. If you keep using this website, you are accepting those.</div>
-                <div class="col-xs-2 text-center">
+                <div class="col-sm-10">We use cookies in this website. Read about them in our <a href="/page/privacy">privacy policy</a>. To disable them, configure your browser properly. If you keep using this website, you are accepting those.</div>
+                <div class="col-sm-2 text-center">
                     <a class="btn btn-primary" href="#">OK</a>
                 </div>
             </div>


### PR DESCRIPTION
Before this patch, the *OK* button was overflowing the horizontal width a little bit in English, but much more in languages where *OK* is a longer word:

![captura el 2017-04-24 a las 11 28 37](https://cloud.githubusercontent.com/assets/973709/25330991/d5a6113e-28e1-11e7-9c38-3dc2f6d23eca.png)


Now the button goes below the message in phones, avoiding that problem:

![captura el 2017-04-24 a las 11 30 28](https://cloud.githubusercontent.com/assets/973709/25331003/da5b1cb0-28e1-11e7-9e3b-45c4387cbf40.png)

@Tecnativa