### PR TITLE
[FIX][website_legal_page] Fix links in reusable template

### DIFF
--- a/website_legal_page/__manifest__.py
+++ b/website_legal_page/__manifest__.py
@@ -7,7 +7,7 @@
     'name': "Website Legal Page",
     'description': 'Add legal information, such as privacy policy',
     'category': 'Website',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'depends': [
         'website',
     ],

--- a/website_legal_page/views/reusable_templates.xml
+++ b/website_legal_page/views/reusable_templates.xml
@@ -3,9 +3,9 @@
 
 <!-- Base templates for submodules -->
 <template id="acceptance_full">
-    I accept the <a href="/page/legal">legal advice</a>, the
-    <a href="/page/privacy">privacy policy</a>, and the
-    <a href="/page/terms">terms of use</a> of this website.
+    I accept the <a href="/legal/advice">legal advice</a>, the
+    <a href="/legal/privacy-policy">privacy policy</a>, and the
+    <a href="/legal/terms-of-use">terms of use</a> of this website.
 </template>
 
 </odoo>


### PR DESCRIPTION
Problem introduced when changing the controllers in #353.

Nobody noticed because the reusable template was not being reused yet, but I'm migrating addons that do and here's the patch.

This should be quite obvious.

@tecnativa