### PR TITLE
[FIX] Remove lib from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
* Lib folder is standard for web repo static directories, so should not be in gitignore