### PR TITLE
add missing space before caret

### DIFF
--- a/website_legal_page/__manifest__.py
+++ b/website_legal_page/__manifest__.py
@@ -7,7 +7,7 @@
     'name': "Website Legal Page",
     'description': 'Add legal information, such as privacy policy',
     'category': 'Website',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'depends': [
         'website',
     ],

--- a/website_legal_page/views/website_legal.xml
+++ b/website_legal_page/views/website_legal.xml
@@ -6,7 +6,7 @@
           inherit_id="website.layout_footer_copyright"
           name="Legal advice Link">
     <xpath expr="//footer//div/span[@t-field='res_company.name']" position="after">
-        <span>- <a href="/legal/advice">Legal Advice</a></span>
+        <span> - <a href="/legal/advice">Legal Advice</a></span>
     </xpath>
 </template>
 

--- a/website_legal_page/views/website_privacy.xml
+++ b/website_legal_page/views/website_privacy.xml
@@ -6,7 +6,7 @@
           inherit_id="website.layout_footer_copyright"
           name="Privacy policy Link">
     <xpath expr="//footer//div/span[@t-field='res_company.name']" position="after">
-        <span>- <a href="/legal/privacy-policy">Privacy Policy</a></span>
+        <span> - <a href="/legal/privacy-policy">Privacy Policy</a></span>
     </xpath>
 </template>
 

--- a/website_legal_page/views/website_terms.xml
+++ b/website_legal_page/views/website_terms.xml
@@ -6,7 +6,7 @@
           inherit_id="website.layout_footer_copyright"
           name="Terms of use Link">
     <xpath expr="//footer//div/span[@t-field='res_company.name']" position="after">
-        <span>- <a href="/legal/terms-of-use">Terms of use</a></span>
+        <span> - <a href="/legal/terms-of-use">Terms of use</a></span>
     </xpath>
 </template>
 


### PR DESCRIPTION
Add space missing between company name and caret. It doesn't hurt to have 2 consecutive space in case there is already one (like between "Privacy Policy" and "Legal Advice"), because html hide them.