### PR TITLE
[imp] website_legal: show Company Registry if valued

### DIFF
--- a/website_legal_page/__manifest__.py
+++ b/website_legal_page/__manifest__.py
@@ -7,7 +7,7 @@
     'name': "Website Legal Page",
     'description': 'Add legal information, such as privacy policy',
     'category': 'Website',
-    'version': '10.0.1.1.0',
+    'version': '10.0.2.0.0',
     'depends': [
         'website',
     ],

--- a/website_legal_page/__manifest__.py
+++ b/website_legal_page/__manifest__.py
@@ -7,7 +7,7 @@
     'name': "Website Legal Page",
     'description': 'Add legal information, such as privacy policy',
     'category': 'Website',
-    'version': '10.0.2.0.0',
+    'version': '10.0.1.3.0',
     'depends': [
         'website',
     ],

--- a/website_legal_page/views/website_legal.xml
+++ b/website_legal_page/views/website_legal.xml
@@ -48,6 +48,11 @@
               </p>
             </div>
             <div>
+              <t t-if="res_company.company_registry">
+                <p>
+                  Company Registry: <span t-field="res_company.company_registry"/>
+                </p>
+              </t>
               <t t-if="res_company.vat">
                 <p>
                   VAT number: <span t-field="res_company.vat"/>


### PR DESCRIPTION
Add field company_registry. 
Please note : curently that field is not checked in Odoo and can contain any other legal information. Useful to provide required legal mention in various country.