### PR TITLE
[10.0][FIX] website_form_recaptcha: reset the recaptcha when the server send a error

### DIFF
--- a/website_form_recaptcha/__manifest__.py
+++ b/website_form_recaptcha/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Website Form - ReCaptcha",
     "summary": 'Provides a ReCaptcha field for Website Forms',
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Website",
     "website": "https://laslabs.com/",
     "author": "LasLabs, Odoo Community Association (OCA)",

--- a/website_form_recaptcha/static/src/js/field_recaptcha.js
+++ b/website_form_recaptcha/static/src/js/field_recaptcha.js
@@ -26,6 +26,13 @@ odoo.define('website_form_recaptcha.recaptcha', function(require){
                     }
                 },
             });
+        },
+
+        update_status: function(status) {
+            this._super(status);
+            if (status === 'error') {
+                if (window.grecaptcha) grecaptcha.reset();
+            }
         }
 
     });


### PR DESCRIPTION
When the form is sent, and a error occur at the creation of the object (by constraint for example) the recaptcha isn't reset but the recaptcha key is already checked by google.
The second time the form is sent, the key isn't changed, and google will reject it.

This pr reset the recaptcha to obtain a new key from google when the user recheck it.