### PR TITLE
[FIX] point inherit to copied views

### DIFF
--- a/website_multi_theme/__manifest__.py
+++ b/website_multi_theme/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Website Multi Theme",
     "summary": "Support different theme per website",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/website_multi_theme/models/website.py
+++ b/website_multi_theme/models/website.py
@@ -48,6 +48,10 @@ class Website(models.Model):
             self._multi_theme_activate()
         return result
 
+    def _find_duplicate_view_for_website(self, origin_view, website):
+        xmlid = VIEW_KEY % (website.id, origin_view.id)
+        return self.env.ref(xmlid, raise_if_not_found=False)
+
     def _duplicate_view_for_website(self, pattern, xmlid, override_key):
         """Duplicate a view pattern and enable it only for current website.
 
@@ -169,6 +173,25 @@ class Website(models.Model):
                         copied_view.inherit_id = custom_layout
                         data.attrib["inherit_id"] = custom_layout.key
                     copied_view.arch = etree.tostring(data)
+                else:
+                    theme_module_name \
+                        = website.multi_theme_id.converted_theme_addon
+
+                    parent_view = copied_view.inherit_id
+                    parent_view_module = parent_view.model_data_id.module
+                    copied_parent = None
+
+                    if parent_view_module == theme_module_name:
+                        # it inherits view of the same module,
+                        # which might be copied
+                        copied_parent = self._find_duplicate_view_for_website(
+                            parent_view, website
+                        )
+
+                    if copied_parent:
+                        copied_view.inherit_id = copied_parent
+                        data.attrib["inherit_id"] = copied_parent.key
+
                 custom_views |= copied_view
             # Delete any custom view that should exist no more
             (website.multi_theme_view_ids - custom_views).unlink()

--- a/website_multi_theme/static/src/js/theme.js
+++ b/website_multi_theme/static/src/js/theme.js
@@ -12,7 +12,7 @@ odoo.define('website_multi_theme.theme', function(require){
     }
 
     theme.include({
-        update_style: function (enable, disable, reload) {
+        update_style: function () {
             var links = multi_theme_links();
             if (links.length) {
                 // Placeholder for dynamically-loaded assets upstream
@@ -28,5 +28,5 @@ odoo.define('website_multi_theme.theme', function(require){
 
     return {
         multi_theme_links: multi_theme_links,
-    }
+    };
 });


### PR DESCRIPTION
Otherwise, theme_customize doesn't work when we have a chain of views like in
``theme_clean``:

`theme_clean.option_bg_shade_light2` inherits `theme_clean.less`
`theme_clean.less` inherits `website.assets_frontend`

without this update, `website_multi_theme` copies
`theme_clean.option_bg_shade_light2` but keeps `inherit_id` the same (i.e. to
`theme_clean.less`, which is not used, because it has a copy)