### PR TITLE
[FIX] "Customize Theme" for theme_anelusia didn't' work

### DIFF
--- a/website_multi_theme/__manifest__.py
+++ b/website_multi_theme/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Website Multi Theme",
     "summary": "Support different theme per website",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/website_multi_theme/controllers/__init__.py
+++ b/website_multi_theme/controllers/__init__.py
@@ -1,5 +1,3 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from . import models
-from . import wizards
-from . import controllers
+from . import main

--- a/website_multi_theme/controllers/main.py
+++ b/website_multi_theme/controllers/main.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Ivan Yelizariev <https://it-projects.info/team/yelizariev>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.http import request, route
+from odoo.addons.website.controllers.main import Website
+
+
+class WebsiteMultiTheme(Website):
+
+    def _xml_id2key(self, xml_id):
+        view = request.env.ref(xml_id, raise_if_not_found=False)
+        if view:
+            return view.key
+        return None
+
+    @route()
+    def theme_customize_get(self, xml_ids):
+        """Extend in order to replace xml_id to key, because
+        view.xml_id is 'website_multi_theme.auto_view_ID_WEBSITE',
+        while client works with original IDs.
+
+        """
+        res = super(WebsiteMultiTheme, self).theme_customize_get(xml_ids)
+        res = [[
+            self._xml_id2key(xml_id) or xml_id
+            for xml_id in group
+        ] for group in res]
+        return res


### PR DESCRIPTION
original method theme_customize_get returns view.xml_id, which are
'website_multi_theme.auto_view_ID_WEBSITE', while client works with original
IDs.

It leads to problem with, for example, theme_anelusia, because it has more than
one setting in its wizard. Without this commit it saves only one setting and
disable all other