### PR TITLE
[FIX] website_form_builder: Usability fixes

### DIFF
--- a/website_form_builder/__manifest__.py
+++ b/website_form_builder/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Website Form Builder",
     "summary": "Build customized forms in your website",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Website",
     "website": "https://github.com/OCA/website",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/website_form_builder/static/src/js/snippets.js
+++ b/website_form_builder/static/src/js/snippets.js
@@ -188,6 +188,7 @@ odoo.define('website_form_builder.snippets', function (require) {
 
         clean_for_save: function () {
             var fields = this.present_fields();
+            this.ensure_section_send();
             // Sync HTML metadata of custom fields with UI
             this.$("[data-model-field=false]").each(function () {
                 var $el = $(this),
@@ -233,6 +234,33 @@ odoo.define('website_form_builder.snippets', function (require) {
         drop_and_build_snippet: function () {
             this.ask_model();
             this._super.apply(this, arguments);
+            this.ensure_section_send();
+        },
+
+        /**
+         * Make sure it has a section to send and receive feedback.
+         */
+        ensure_section_send: function () {
+            var send_section = this.$(
+                ".form-group:has(.o_website_form_send)" +
+                           ":has(#o_website_form_result)"
+            );
+            if (send_section.is(":visible")) {
+                return;
+            }
+            // Remove possibly garbagey section
+            this.$(".o_website_form_fields+.form-group").remove();
+            _templates_loaded.done($.proxy(this, "_add_section_send"));
+        },
+
+        /**
+         * Append a section to send and receive feedback.
+         */
+        _add_section_send: function () {
+            this.$("form").append(core.qweb.render(
+                "website_form_builder.section.send",
+                {option: this}
+            ));
         },
 
         /**

--- a/website_form_builder/static/src/xml/snippets.xml
+++ b/website_form_builder/static/src/xml/snippets.xml
@@ -50,7 +50,9 @@
                     class="o_website_form_input"
                     value="1"
                 />
-                <t t-esc="field.string"/>
+                <span>
+                    <t t-esc="field.string"/>
+                </span>
             </label>
         </t>
     </t>
@@ -210,5 +212,15 @@
                 type="text"
             />
         </t>
+    </t>
+
+    <t t-name="website_form_builder.section.send">
+        <div class="form-group">
+            <button type="button"
+                    class="btn btn-primary btn-lg o_website_form_send o_default_snippet_text">
+                Send
+            </button>
+            <span id="o_website_form_result"/>
+        </div>
     </t>
 </template>

--- a/website_form_builder/templates/snippets.xml
+++ b/website_form_builder/templates/snippets.xml
@@ -23,13 +23,6 @@
                         disappearing when emptied
                     </div>
                 </div>
-                <div class="form-group">
-                    <button type="button"
-                            class="btn btn-primary btn-lg o_website_form_send o_default_snippet_text">
-                        Send
-                    </button>
-                    <span id="o_website_form_result"/>
-                </div>
             </form>
         </section>
     </template>


### PR DESCRIPTION
- Allow Firefox users to edit boolean field labels. The addon included a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=853519, but it was incomplete without this patch.
- On save, restore send button and feedback section if the user accidentally removed any of them.

Notice that the addon is still affected by https://github.com/odoo/odoo/pull/23852, but that's another issue.

@Tecnativa