### PR TITLE
[FIX] website_multi_theme: Manage only Qweb views

### DIFF
--- a/website_multi_theme/__manifest__.py
+++ b/website_multi_theme/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Website Multi Theme",
     "summary": "Support different theme per website",
-    "version": "10.0.1.0.4",
+    "version": "10.0.1.1.0",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/website_multi_theme/migrations/10.0.1.1.0/pre-migrate.py
+++ b/website_multi_theme/migrations/10.0.1.1.0/pre-migrate.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Jairo Llopis
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+
+def migrate(cr, version):
+    """Restore affected non-qweb views."""
+    cr.execute("""
+        DELETE FROM ir_ui_view
+        WHERE type != 'qweb' AND multi_theme_generated = TRUE
+    """)
+    cr.execute("""
+        UPDATE ir_ui_view
+        SET active = TRUE, was_active = FALSE
+        WHERE type != 'qweb' AND was_active = TRUE
+    """)

--- a/website_multi_theme/models/website_theme.py
+++ b/website_multi_theme/models/website_theme.py
@@ -42,8 +42,12 @@ class WebsiteTheme(models.Model):
                 ("module", "=", one.converted_theme_addon),
                 ("model", "=", "ir.ui.view"),
             ])
+            views = self.env["ir.ui.view"].search([
+                ("id", "in", refs.mapped("res_id")),
+                ("type", "=", "qweb"),
+            ])
             existing = frozenset(one.mapped("asset_ids.name"))
-            expected = frozenset(refs.mapped("complete_name"))
+            expected = frozenset(views.mapped("xml_id"))
             dangling = tuple(existing - expected)
             # Create a new asset for each theme view
             for ref in expected - existing:


### PR DESCRIPTION
Current implementation disabled all backend views from a theme addon when converting it to multiwebsite mode.

This is now fixed, and includes a migration script to make things work again if you hit this situation in your database.

@Tecnativa