### PR TITLE
[CI] cleanup

### DIFF
--- a/website_legal_page/tests/test_controller.py
+++ b/website_legal_page/tests/test_controller.py
@@ -9,7 +9,7 @@ from odoo.tools import mute_logger
 class TestController(HttpCase):
 
     def _test_page(self, page, code=200):
-        response = self.url_open(page, timeout=20)
+        response = self.url_open(page, timeout=40)
         self.assertEqual(response.getcode(), code)
 
     @mute_logger("odoo.addons.website.models.ir_ui_view")

--- a/website_snippet_barcode/static/tests/js/website_snippet_barcode.editor.tour.js
+++ b/website_snippet_barcode/static/tests/js/website_snippet_barcode.editor.tour.js
@@ -25,7 +25,7 @@ odoo.define("website_snippet_barcode.tour_editor", function (require) {
     }
 
     tour.register("website_snippet_barcode", {
-        url: '/?debug=assets&enable_editor=1',
+        url: '/?enable_editor=1',
         test: true,
         wait_for: base.ready()
     }, [{


### PR DESCRIPTION
see https://travis-ci.org/OCA/website/jobs/372102573

```

2018-04-27 16:08:44,696 5644 INFO openerp_test odoo.addons.website_legal_page.tests.test_controller: ======================================================================
2018-04-27 16:08:44,696 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: ERROR: test_advice (odoo.addons.website_legal_page.tests.test_controller.TestController)
2018-04-27 16:08:44,697 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: ` It should return a 200 for advice page.
2018-04-27 16:08:44,697 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: Traceback (most recent call last):
2018-04-27 16:08:44,697 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/home/travis/build/OCA/website/website_legal_page/tests/test_controller.py", line 26, in test_advice
2018-04-27 16:08:44,698 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     self._test_page('/legal/advice')
2018-04-27 16:08:44,698 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/home/travis/build/OCA/website/website_legal_page/tests/test_controller.py", line 12, in _test_page
2018-04-27 16:08:44,698 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     response = self.url_open(page, timeout=20)
2018-04-27 16:08:44,698 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/home/travis/OCB-10.0/odoo/tests/common.py", line 272, in url_open
2018-04-27 16:08:44,698 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     return self.opener.open(url, data, timeout)
2018-04-27 16:08:44,698 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/urllib2.py", line 404, in open
2018-04-27 16:08:44,699 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     response = self._open(req, data)
2018-04-27 16:08:44,699 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/urllib2.py", line 422, in _open
2018-04-27 16:08:44,699 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     '_open', req)
2018-04-27 16:08:44,699 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/urllib2.py", line 382, in _call_chain
2018-04-27 16:08:44,699 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     result = func(*args)
2018-04-27 16:08:44,699 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/urllib2.py", line 1214, in http_open
2018-04-27 16:08:44,699 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     return self.do_open(httplib.HTTPConnection, req)
2018-04-27 16:08:44,700 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/urllib2.py", line 1187, in do_open
2018-04-27 16:08:44,700 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     r = h.getresponse(buffering=True)
2018-04-27 16:08:44,700 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/httplib.py", line 1089, in getresponse
2018-04-27 16:08:44,700 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     response.begin()
2018-04-27 16:08:44,700 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/httplib.py", line 444, in begin
2018-04-27 16:08:44,700 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     version, status, reason = self._read_status()
2018-04-27 16:08:44,700 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/httplib.py", line 400, in _read_status
2018-04-27 16:08:44,701 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     line = self.fp.readline(_MAXLINE + 1)
2018-04-27 16:08:44,701 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `   File "/usr/lib/python2.7/socket.py", line 476, in readline
2018-04-27 16:08:44,701 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: `     data = self._sock.recv(self._rbufsize)
2018-04-27 16:08:44,701 5644 ERROR openerp_test odoo.addons.website_legal_page.tests.test_controller: ` timeout: timed out
```