### PR TITLE
[FIX] website_multi_theme: duplicates creation must be done in correct order

### DIFF
--- a/website_multi_theme/__manifest__.py
+++ b/website_multi_theme/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Website Multi Theme",
     "summary": "Support different theme per website",
-    "version": "10.0.1.3.3",
+    "version": "10.0.1.4.0",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Tecnativa, IT-Projects LLC, Odoo Community Association (OCA)",

--- a/website_multi_theme/models/website_theme.py
+++ b/website_multi_theme/models/website_theme.py
@@ -131,6 +131,7 @@ class WebsiteTheme(models.Model):
 
 class WebsiteThemeAsset(models.Model):
     _name = "website.theme.asset"
+    _order = 'view_priority,view_id,id'
     _sql_constraints = [
         ("name_theme_uniq", "UNIQUE(name, theme_id)",
          "Name must be unique in each theme"),
@@ -154,7 +155,11 @@ class WebsiteThemeAsset(models.Model):
         help="View that will be enabled when this theme is used in any "
              "website, and disabled otherwise. Usually used to load assets.",
     )
-
+    view_priority = fields.Integer(
+        related='view_id.priority',
+        store=True,
+        readonly=True,
+    )
     auto = fields.Boolean(
         string="Auto-generated",
         help="Created automatically from theme view",


### PR DESCRIPTION
After introducing sub-themes https://github.com/OCA/website/pull/454, it's essential to be sure that views are copied in a correct order.

 Imagine that Theme has two *theme-dependencies* where one depends (i.e. as in manifest) on another. In that case ``website.theme.asset`` records for those *theme-dependencies* can be created in a random order. It might lead to a mess when we copy firstly view that extends not-copied yet view from another *theme-dependency*.
