### PR TITLE
[10.0][FIX][website_multi_theme] button method cannot be api.model

### DIFF
--- a/website_multi_theme/__manifest__.py
+++ b/website_multi_theme/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Website Multi Theme",
     "summary": "Support different theme per website",
-    "version": "10.0.1.3.2",
+    "version": "10.0.1.3.3",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Tecnativa, IT-Projects LLC, Odoo Community Association (OCA)",

--- a/website_multi_theme/data/themes_default.xml
+++ b/website_multi_theme/data/themes_default.xml
@@ -16,5 +16,6 @@
     <!-- This method prepare assets and applies default theme for all websites -->
     <function model="website.config.settings"
               name="multi_theme_reload"
+              eval="([],)"
               />
 </odoo>

--- a/website_multi_theme/models/website.py
+++ b/website_multi_theme/models/website.py
@@ -202,9 +202,13 @@ class Website(models.Model):
             views_to_remove = website.multi_theme_view_ids - custom_views
             # Removed views could be a copied parent for others
             # So, replace to original parent first
-            for view in self.env['ir.ui.view'].search([
-                    ('inherit_id', 'in', views_to_remove.ids)
-            ]):
+            views_to_replace_parent = \
+                self.env['ir.ui.view']\
+                    .with_context(active_test=False)\
+                    .search([
+                        ('inherit_id', 'in', views_to_remove.ids)
+                    ])
+            for view in views_to_replace_parent:
                 view._replace_parent(view.inherit_id.origin_view_id)
             views_to_remove.unlink()
             _logger.info(

--- a/website_multi_theme/wizards/website_config_settings.py
+++ b/website_multi_theme/wizards/website_config_settings.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from odoo import fields, models, api
+from odoo import fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -14,7 +14,6 @@ class WebsiteConfigSettings(models.TransientModel):
 
     multi_theme_id = fields.Many2one(related="website_id.multi_theme_id")
 
-    @api.model
     def multi_theme_reload(self):
         """Update multiwebsite themes when loading a new wizard."""
         _logger.info("Reloading available multi-website themes")


### PR DESCRIPTION
While the method doesn't use recordset, it must be decorated with ``api.multi``, otherwise we get error on clicking the button:

```
  File "/mnt/odoo-source/addons/web/controllers/main.py", line 896, in call_button
    action = self._call_kw(model, method, args, {})
  File "/mnt/odoo-source/addons/web/controllers/main.py", line 884, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/mnt/odoo-source/odoo/api.py", line 687, in call_kw
    return call_kw_model(method, model, args, kwargs)
  File "/mnt/odoo-source/odoo/api.py", line 670, in call_kw_model
    recs = self.with_context(context or {})
  File "/mnt/odoo-source/odoo/models.py", line 4911, in with_context
    context = dict(args[0] if args else self._context, **kwargs)
TypeError: cannot convert dictionary update sequence element #0 to a sequence
```