### PR TITLE
[IMP] website_cookie_notice: append cookie notice inside header

### DIFF
--- a/website_cookie_notice/templates/website.xml
+++ b/website_cookie_notice/templates/website.xml
@@ -25,7 +25,7 @@
 </template>
 
 <template id="cookiebanner" inherit_id="website.layout">
-    <xpath expr="//header" position="before">
+    <xpath expr="//header" position="inside">
         <t t-call="website_cookie_notice.message"/>
     </xpath>
 </template>


### PR DESCRIPTION
If the cookie_notice is used with [this theme](https://github.com/OCA/website-themes/tree/11.0/website_theme_flexible) with sticky enabled then content of cookie gets hidden inside the fixed navbar and pushes the underlying navbar down. This commit fixes the issue. 