### PR TITLE
[FIX] subsections in README

### DIFF
--- a/website_addthis/readme/CONFIGURE.rst
+++ b/website_addthis/readme/CONFIGURE.rst
@@ -3,7 +3,7 @@
 #. set your "Public ID" (find it in your profile on addthis.com)
 
 Advanced Settings
------------------
+~~~~~~~~~~~~~~~~~
 
 If you have debug mode on or your user has "Technical Features" group,
 you'll see an additiona field "Advanced JS config".


### PR DESCRIPTION
@simahawk 

Subsections are not allowed in README fragments. If you really want one, only one level is supported, using tilde as underline.

Also be careful with images: an image path relative to a fragment will not work relative to the generated README.rst in the root directory.