### PR TITLE
[10.0][FIX] add_domain was not being evaluated (#554)

### DIFF
--- a/website_field_autocomplete/static/src/js/field_autocomplete.js
+++ b/website_field_autocomplete/static/src/js/field_autocomplete.js
@@ -19,7 +19,8 @@ odoo.define('website_field_autocomplete.field_autocomplete', function(require){
       var self = this;
       var domain = [[this.queryField, 'ilike', request.term]];
       if (this.add_domain) {
-        domain = domain.concat(this.add_domain);
+        var add_domain = JSON.parse(this.add_domain.replace(/\'/g, '"'));
+        domain = domain.concat(add_domain);
       }
       return $.ajax({
         dataType: 'json',


### PR DESCRIPTION
This fixes https://github.com/OCA/website/issues/554

At first, I tried to use `pyeval`, but then realized it's not available on website, only on backend.
