### PR TITLE
[IMP] 11.0 website_form_recaptcha improve JS

### DIFF
--- a/website_form_recaptcha/README.rst
+++ b/website_form_recaptcha/README.rst
@@ -25,6 +25,10 @@ To use this module, you need to:
 * Set `website_form_recaptcha` to `True` on that model (similar to enabling forms)
 * Add an element with the `o_website_form_recaptcha` class anywhere in the form
 
+Captcha will try to use the language of your website. If it, for whatever
+reason, can't find, it will default to google API and use the language of the
+browser.
+
 Look at `website_crm_recaptcha` module for example implementation
 
 
@@ -55,6 +59,7 @@ Contributors
 ------------
 
 * Dave Lasley <dave@laslabs.com>
+* Mykhailo Panarin <m.panarin@mobilunity.com>
 
 Maintainer
 ----------

--- a/website_form_recaptcha/__manifest__.py
+++ b/website_form_recaptcha/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Website Form - ReCaptcha",
     "summary": 'Provides a ReCaptcha field for Website Forms',
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "category": "Website",
     "website": "https://github.com/OCA/website",
     "author": "LasLabs, Odoo Community Association (OCA)",


### PR DESCRIPTION
* Make JS easier to extend (for example, when captcha api params are required)
* Make enforce language when possible (auto-detect can fail if browser lang is different)