### PR TITLE
website_form_recaptcha: fix and backward compat

### DIFF
--- a/website_form_recaptcha/__manifest__.py
+++ b/website_form_recaptcha/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Website Form - ReCaptcha",
     "summary": 'Provides a ReCaptcha field for Website Forms',
-    "version": "11.0.1.2.0",
+    "version": "11.0.1.2.1",
     "category": "Website",
     "website": "https://github.com/OCA/website",
     "author": "LasLabs, Odoo Community Association (OCA)",

--- a/website_form_recaptcha/models/website_form_recaptcha.py
+++ b/website_form_recaptcha/models/website_form_recaptcha.py
@@ -4,7 +4,10 @@
 
 from odoo import models, api, http, _
 from odoo.exceptions import ValidationError
+import logging
 import requests
+
+_logger = logging.getLogger(__name__)
 
 
 class WebsiteFormRecaptcha(models.AbstractModel):
@@ -16,10 +19,12 @@ class WebsiteFormRecaptcha(models.AbstractModel):
     _description = 'Website Form Recaptcha Validations'
     URL = 'https://www.google.com/recaptcha/api/siteverify'
     RESPONSE_ATTR = 'g-recaptcha-response'
+    # name of the token attr to store on the request object
+    REQUEST_TOKEN = RESPONSE_ATTR.replace('-', '_')
 
     @api.model
     def _get_error_message(self, errorcode=None):
-        map = {
+        mapping = {
             'missing-input-secret': _('The secret parameter is missing.'),
             'invalid-input-secret':
                 _('The secret parameter is invalid or malformed.'),
@@ -27,8 +32,8 @@ class WebsiteFormRecaptcha(models.AbstractModel):
             'invalid-input-response':
                 _('The response parameter is invalid or malformed.'),
         }
-        return map.get(errorcode, _('There was a problem with '
-                                    'the captcha entry.'))
+        return mapping.get(errorcode, _('There was a problem with '
+                                        'the captcha entry.'))
 
     def _get_api_params(self):
         ICP = self.env['ir.config_parameter'].sudo()
@@ -80,32 +85,59 @@ class WebsiteFormRecaptcha(models.AbstractModel):
 
         if not res.get('success'):
             raise ValidationError(self._get_error_message())
-
         return True
 
     @api.model
     def validate_request(self, request, values):
-        # Only check once: if a call to reCAPTCHA's API is made twice with
-        # the same token, we get a 'timeout-or-duplicate' error. So we
-        # stick to the first response data storing the token after the
-        # first invoke in the current request object. This duplicated
-        # call can be cause for instance by website_crm_phone_validation.
-        try:
-            getattr(request, self.RESPONSE_ATTR)
-        except AttributeError:
-            return None
+        old_value = getattr(request, self.REQUEST_TOKEN, None)
+        if old_value is not None:
+            # Only check once: if a call to reCAPTCHA's API is made twice with
+            # the same token, we get a 'timeout-or-duplicate' error. So we
+            # stick to the first response data storing the token after the
+            # first invoke in the current request object. This duplicated
+            # call can be cause for instance by website_crm_phone_validation.
+            return True
+        req_value = values.get(self.RESPONSE_ATTR)
+        if not req_value:
+            raise ValidationError(
+                self._get_error_message('missing-input-secret')
+            )
         ip_addr = request.httprequest.environ.get('HTTP_X_FORWARDED_FOR')
         if ip_addr:
             ip_addr = ip_addr.split(',')[0]
         else:
             ip_addr = request.httprequest.remote_addr
-        try:
-            self.validate_response(
-                values.get(self.RESPONSE_ATTR), ip_addr
-            )
-            # Store reCAPTCHA's token in the current request object
-            setattr(
-                request, self.RESPONSE_ATTR, values.get(self.RESPONSE_ATTR)
-            )
-        except ValidationError:
-            raise ValidationError([self.RESPONSE_ATTR])
+        # if not validated an exception is raised anyway
+        validated = self.validate_response(req_value, ip_addr)
+        # Store reCAPTCHA's token in the current request object
+        setattr(request, self.REQUEST_TOKEN, req_value)
+        return validated
+
+    # TODO: backward compat, remove in v12
+    @api.model
+    def action_validate(self, req_value, ip_addr, website=None):
+        """Backward compatibility for old implementation.
+
+        Prior to API refactoring in this module (see f46d879a)
+        pre-validation steps were made in the controller
+        and were calling `action_validate`. This method is deprecated now.
+
+        In such cases your code looked like:
+
+            try:
+                captcha_obj.action_validate(
+                    values.get(captcha_obj.RESPONSE_ATTR), ip_addr
+                )
+                # Store reCAPTCHA's token in the current request object
+                setattr(request, captcha_obj.RESPONSE_ATTR,
+                        values.get(captcha_obj.RESPONSE_ATTR))
+            except ValidationError:
+                raise ValidationError([captcha_obj.RESPONSE_ATTR])
+
+        Note: the request token name to store validated value
+        is now defined into `REQUEST_TOKEN`.
+        """
+        _logger.warning(
+            '`action_validate` is deprecated: use `validate_request`'
+        )
+        return self.validate_response(req_value, ip_addr, website=website)

--- a/website_form_recaptcha/readme/HISTORY.rst
+++ b/website_form_recaptcha/readme/HISTORY.rst
@@ -1,3 +1,11 @@
+11.0.1.2.1 (Unreleased)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fix handling of request attribute
+* Add backward compatibility for recent API refactoring
+
+  [simahawk]
+
 11.0.1.2.0 (2019-01-10)
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
@chienandalu regarding your change from https://github.com/OCA/website/pull/540 can you check it is properly handled? 
I added a specific test for it, still, better to double check :)

I'd also like to use vcrpy to remove most of the mockings in tests, but this is something that can wait.

I added also some backward compat glue to address issues like https://github.com/OCA/apps-store/pull/46
/cc @bizzappdev @pedrobaeza 