### PR TITLE
website_lazy_load_image: do no wrap non-html

### DIFF
--- a/website_lazy_load_image/models/ir_ui_view.py
+++ b/website_lazy_load_image/models/ir_ui_view.py
@@ -21,7 +21,8 @@ class IrUiView(models.Model):
         res = super(IrUiView, self).render_template(template, values, engine)
         website_id = self.env.context.get('website_id')
         if website_id and not \
-                self.env['website'].browse(website_id).is_publisher():
+                self.env['website'].browse(website_id).is_publisher() and \
+                '<html' in res.decode():
             html = etree.HTML(res)
             imgs = html.xpath(
                 '//main//img[@src][not(hasclass("lazyload-disable"))]'


### PR DESCRIPTION
Pages like robots.txt got wrapped with a `<html>` and `<p>` tag. This change fixes this.