### PR TITLE
[12.0][FIX] website_google_tag_manager: Fix travis error

### DIFF
--- a/website_google_tag_manager/README.rst
+++ b/website_google_tag_manager/README.rst
@@ -23,11 +23,10 @@ Google Tag Manager
     :target: https://runbot.odoo-community.org/runbot/186/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows to configure your Odoo website to support the
-`Google Tag Manager <https://marketingplatform.google.com/about/tag-manager/>`_
-tool.
+`GTM <https://marketingplatform.google.com/about/tag-manager/>`_ tool.
 
 **Table of contents**
 

--- a/website_google_tag_manager/readme/DESCRIPTION.rst
+++ b/website_google_tag_manager/readme/DESCRIPTION.rst
@@ -1,3 +1,3 @@
 This module allows to configure your Odoo website to support the
-`Google Tag Manager <https://marketingplatform.google.com/about/tag-manager/>`_
+`GTM <https://marketingplatform.google.com/about/tag-manager/>`_
 tool.


### PR DESCRIPTION
To fix Travis Error:

************* Module website_google_tag_manager
website_google_tag_manager/README.rst:3: [E7901(rst-syntax-error), ] Duplicate implicit target name: "google tag manager".

cc @Tecnativa