### PR TITLE
[FIX] website_cookie_notice: max-age for cookie

### DIFF
--- a/website_cookie_notice/README.rst
+++ b/website_cookie_notice/README.rst
@@ -69,6 +69,7 @@ Contributors
 * Rafael Blasco <rafael.blasco@tecnativa.com>
 * Jairo Llopis <jairo.llopis@tecnativa.com>
 * Wolfgang Pichler <wpichler@callino.at>
+* Andrius Laukavičius <dev@focusate.eu> (Focusate)
 
 Maintainer
 ----------

--- a/website_cookie_notice/__manifest__.py
+++ b/website_cookie_notice/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Cookie notice',
     'summary': 'Show cookie notice according to cookie law',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Website',
     'author': "Agile Business Group, "
               "Tecnativa, "

--- a/website_cookie_notice/static/src/js/accept_cookies.js
+++ b/website_cookie_notice/static/src/js/accept_cookies.js
@@ -11,7 +11,8 @@ odoo.define('website_cookie_notice.cookie_notice', function (require) {
     base.ready().done(function() {
         $(".cc-cookies .btn-primary").click(function(e) {
             e.preventDefault();
-            document.cookie = 'accepted_cookies=1; path=/';
+            // max-age to store cookie for one year.
+            document.cookie = 'accepted_cookies=1; path=/; max-age=31536000';
             $(e.target).closest(".cc-cookies").hide("fast");
         });
     });


### PR DESCRIPTION
Default cookie behavior is to expire on session. But it is not expected
behavior for cookies consent. So instead we specify max-age to store
cookie up to a year.

Fixes https://github.com/OCA/website/issues/580