### PR TITLE
[FIX][12.0] website_anchor_smooth_scroll travis warning

### DIFF
--- a/website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js
+++ b/website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js
@@ -2,25 +2,25 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 odoo.define('website_anchor_smooth_scroll.website_anchor_smooth_scroll', function (require) {
 
-"use strict";
+    "use strict";
 
-function website_anchor_smooth_scroll(event) {
-    event.preventDefault();
-    var target = $(event.currentTarget.hash);
+    function website_anchor_smooth_scroll (event) {
+        event.preventDefault();
+        var target = $(event.currentTarget.hash);
 
-    return $('html, body')
-    .stop()
-    .animate({
-        'scrollTop': target.offset().top - 100
-    })
-    .promise()
-    .done(function(element) {
-        history.pushState(null, document.title, event.target.hash);
-    });
-}
+        return $('html, body')
+            .stop()
+            .animate({
+                'scrollTop': target.offset().top - 100,
+            })
+            .promise()
+            .done(function () {
+                history.pushState(null, document.title, event.target.hash);
+            });
+    }
 
-require('web.dom_ready');
+    require('web.dom_ready');
 
-$("a[href^='#']:not([href=#])").on("click", website_anchor_smooth_scroll);
+    $("a[href^='#']:not([href=#])").on("click", website_anchor_smooth_scroll);
 
 });


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/598 : 
fix of:
************* Module website_anchor_smooth_scroll
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:5: [W7903(javascript-lint), ] Expected indentation of 4 spaces but found 0. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:7: [W7903(javascript-lint), ] Expected indentation of 4 spaces but found 0. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:7: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:8: [W7903(javascript-lint), ] Expected indentation of 8 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:9: [W7903(javascript-lint), ] Expected indentation of 8 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:11: [W7903(javascript-lint), ] Expected indentation of 8 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:12: [W7903(javascript-lint), ] Expected indentation of 12 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:13: [W7903(javascript-lint), ] Expected indentation of 12 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:14: [W7903(javascript-lint), ] Expected indentation of 16 spaces but found 8. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:14: [W7903(javascript-lint), ] Missing trailing comma. [Error/comma-dangle]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:15: [W7903(javascript-lint), ] Expected indentation of 12 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:16: [W7903(javascript-lint), ] Expected indentation of 12 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:17: [W7903(javascript-lint), ] Expected indentation of 12 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:17: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:17: [W7903(javascript-lint), ] 'element' is defined but never used. [Error/no-unused-vars]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:18: [W7903(javascript-lint), ] Expected indentation of 16 spaces but found 8. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:19: [W7903(javascript-lint), ] Expected indentation of 12 spaces but found 4. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:20: [W7903(javascript-lint), ] Expected indentation of 4 spaces but found 0. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:22: [W7903(javascript-lint), ] Expected indentation of 4 spaces but found 0. [Error/indent]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:24: [W7903(javascript-lint), ] Expected indentation of 4 spaces but found 0. [Error/indent]