### PR TITLE
[FIX][12.0] website_cookie_notice travis warning

### DIFF
--- a/website_cookie_notice/static/src/js/accept_cookies.js
+++ b/website_cookie_notice/static/src/js/accept_cookies.js
@@ -9,14 +9,15 @@ odoo.define('website_cookie_notice.cookie_notice', function (require) {
     var ajax = require('web.ajax');
     var base = require('web_editor.base');
 
-    base.ready().done(function() {
-        $(".cc-cookies .btn-primary").click(function(e) {
+    base.ready().done(function () {
+        $(".cc-cookies .btn-primary").click(function (e) {
             e.preventDefault();
-            ajax.jsonRpc('/website_cookie_notice/ok', 'call').then(function (data) {
-                if (data.result == 'ok') {
-                    $(e.target).closest(".cc-cookies").hide("fast");
-                }
-            });
+            ajax.jsonRpc('/website_cookie_notice/ok', 'call')
+                .then(function (data) {
+                    if (data.result === 'ok') {
+                        $(e.target).closest(".cc-cookies").hide("fast");
+                    }
+                });
         });
     });
 }


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/598 :
fix of:
************* Module website_cookie_notice
website_cookie_notice/static/src/js/accept_cookies.js:12: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_cookie_notice/static/src/js/accept_cookies.js:13: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_cookie_notice/static/src/js/accept_cookies.js:15: [W7903(javascript-lint), ] Line 15 exceeds the maximum line length of 80. [Error/max-len]
website_cookie_notice/static/src/js/accept_cookies.js:16: [W7903(javascript-lint), ] Expected '===' and instead saw '=='. [Error/eqeqeq]


can someone please confirm the correctness of "website_cookie_notice/static/src/js/accept_cookies.js:16: [W7903(javascript-lint), ] Expected '===' and instead saw '=='. [Error/eqeqeq]"