### PR TITLE
[FIX][11.0] website_form_metadata travis warning

### DIFF
--- a/website_form_metadata/__init__.py
+++ b/website_form_metadata/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import models

--- a/website_form_metadata/__manifest__.py
+++ b/website_form_metadata/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 David Vidal <david.vidal@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {

--- a/website_form_metadata/models/__init__.py
+++ b/website_form_metadata/models/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import res_config_settings

--- a/website_form_metadata/models/res_config_settings.py
+++ b/website_form_metadata/models/res_config_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 David Vidal <david.vidal@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/603 : 
fix of:
************* Module website_form_metadata
website_form_metadata/init.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
************* Module website_form_metadata.manifest
website_form_metadata/manifest.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
************* Module website_form_metadata.models.res_config_settings
website_form_metadata/models/res_config_settings.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
************* Module website_form_metadata.models.init
website_form_metadata/models/init.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary