### PR TITLE
[FIX][11.0] website_crm_privacy_policy travis warning

### DIFF
--- a/website_crm_privacy_policy/__manifest__.py
+++ b/website_crm_privacy_policy/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014 Jorge Camacho <jcamacho@trey.es>
 # Copyright 2015 Antonio Espinosa <antonioea@antiun.com>
 # Copyright 2016-2018 Vicent Cubells <vicent.cubells@tecnativa.com>


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/603 : 
fix of:
************* Module website_crm_privacy_policy.manifest
website_crm_privacy_policy/manifest.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary