### PR TITLE
[FIX][10.0] website_multi_theme travis warn

### DIFF
--- a/website_multi_theme/static/src/js/theme.js
+++ b/website_multi_theme/static/src/js/theme.js
@@ -1,7 +1,7 @@
 /* Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
 
-odoo.define('website_multi_theme.theme', function(require){
+odoo.define('website_multi_theme.theme', function (require) {
     "use strict";
 
     var theme = require('website.theme');
@@ -23,7 +23,7 @@ odoo.define('website_multi_theme.theme', function(require){
             return this._super.apply(this, arguments).done(function () {
                 links.remove();
             });
-        }
+        },
     });
 
     return {


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/604 : 
fix of:
************* Module website_multi_theme
website_multi_theme/static/src/js/theme.js:4: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_multi_theme/static/src/js/theme.js:4: [W7903(javascript-lint), ] Missing space before opening brace. [Error/space-before-blocks]
website_multi_theme/static/src/js/theme.js:26: [W7903(javascript-lint), ] Missing trailing comma. [Error/comma-dangle]