### PR TITLE
[FIX][10.0] website_cookie_notice travis warn

### DIFF
--- a/website_cookie_notice/static/src/js/accept_cookies.js
+++ b/website_cookie_notice/static/src/js/accept_cookies.js
@@ -8,10 +8,10 @@ odoo.define('website_cookie_notice.cookie_notice', function (require) {
 
     var base = require('web_editor.base');
 
-    base.ready().done(function() {
-        $(".cc-cookies .btn-primary").click(function(e) {
+    base.ready().done(function () {
+        $(".cc-cookies .btn-primary").click(function (e) {
             e.preventDefault();
-            // max-age to store cookie for one year.
+            // Max-age to store cookie for one year.
             document.cookie = 'accepted_cookies=1; path=/; max-age=31536000';
             $(e.target).closest(".cc-cookies").hide("fast");
         });


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/604 : 
fix of: 
************* Module website_cookie_notice
website_cookie_notice/static/src/js/accept_cookies.js:11: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_cookie_notice/static/src/js/accept_cookies.js:12: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]