### PR TITLE
[FIX][10.0] website_blog_category travis warn

### DIFF
--- a/website_blog_category/static/test/js/website_blog_category.tour.js
+++ b/website_blog_category/static/test/js/website_blog_category.tour.js
@@ -1,6 +1,6 @@
 /* Copyright 2017 LasLabs Inc.
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
-odoo.define('website_blog_category.tour', function(require) {
+odoo.define('website_blog_category.tour', function (require) {
     'use strict';
 
     var tour = require('web_tour.tour');


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/604 :  
fix of: 
************* Module website_blog_category
website_blog_category/static/test/js/website_blog_category.tour.js:3: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]