### PR TITLE
[12.0][FIX] website_form_recaptcha: migration scripts

### DIFF
--- a/website_form_recaptcha/migrations/12.0.1.0.0/post-migrate.py
+++ b/website_form_recaptcha/migrations/12.0.1.0.0/post-migrate.py
@@ -5,7 +5,7 @@ from openupgradelib import openupgrade
 
 
 @openupgrade.migrate()
-def migrate(env):
+def migrate(env, version):
     """Move global ``ir.config_parameter`` keys to website."""
     ICP = env["ir.config_parameter"]
     websites = env["website"].search([


### PR DESCRIPTION
The `migrate` method should have two parameters.

![shame](https://media.giphy.com/media/vX9WcCiWwUF7G/giphy.gif)