### PR TITLE
[10.0][FIX] website_legal_page fix travis warn

### DIFF
--- a/website_legal_page/__manifest__.py
+++ b/website_legal_page/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': "Website Legal Page",
-    'description': 'Add legal information, such as privacy policy',
+    'summary': 'Add legal information, such as privacy policy',
     'category': 'Website',
     'version': '10.0.1.2.0',
     'depends': [


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/604
fix of:
************* Module website_legal_page.manifest
website_legal_page/manifest.py:6: [C8103(manifest-deprecated-key), ] Deprecated key "description" in manifest file

travis fails: https://github.com/OCA/website/issues/629