### PR TITLE
[10.0][FIX][WIP] website_anchor_smooth_scroll travis warn

### DIFF
--- a/website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js
+++ b/website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js
@@ -4,25 +4,27 @@
 *    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 **/
 
-odoo.define('website_anchor_smooth_scroll', function(require) {
+odoo.define('website_anchor_smooth_scroll', function (require) {
     'use strict';
 
     var base = require('web_editor.base');
 
-    var smooth_scroll = function(event) {
+    var smooth_scroll = function (event) {
         event.preventDefault();
         var anchor_fragment = event.target.hash;
 
-        // Do this before scrolling so that browser history accurately reflects scroll position at time of click 
+        // Do this before scrolling so that browser history
+        // accurately reflects scroll position at time of click
         history.pushState(null, document.title, anchor_fragment);
 
         return $('html, body').stop().animate({
-            'scrollTop': $(anchor_fragment).offset().top - 100
+            'scrollTop': $(anchor_fragment).offset().top - 100,
         }).promise();
     };
 
-    base.ready().done(function() {
-        $('a[href^="#"][href!="#"][href!="#advanced-view-editor"]').click(smooth_scroll);
+    base.ready().done(function () {
+        $('a[href^="#"][href!="#"][href!="#advanced-view-editor"]')
+            .click(smooth_scroll);
     });
 
     return {'scroll_handler': smooth_scroll};


### PR DESCRIPTION
issue https://github.com/OCA/website/issues/604
fix of:
************* Module website_anchor_smooth_scroll
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:7: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:12: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:16: [W7903(javascript-lint), ] Line 16 exceeds the maximum line length of 80. [Error/max-len]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:16: [W7903(javascript-lint), ] Trailing spaces not allowed. [Error/no-trailing-spaces]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:20: [W7903(javascript-lint), ] Missing trailing comma. [Error/comma-dangle]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:24: [W7903(javascript-lint), ] Missing space before function parentheses. [Error/space-before-function-paren]
website_anchor_smooth_scroll/static/src/js/website_anchor_smooth_scroll.js:25: [W7903(javascript-lint), ] Line 25 exceeds the maximum line length of 80. [Error/max-len]

travis fail: https://github.com/OCA/website/issues/629