### PR TITLE
[FIX] website_lazy_load_image: HTML parsing

### DIFF
--- a/website_lazy_load_image/models/ir_ui_view.py
+++ b/website_lazy_load_image/models/ir_ui_view.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
-from lxml import etree
+import lxml
 
 
 class IrUiView(models.Model):
@@ -22,7 +22,7 @@ class IrUiView(models.Model):
         website_id = self.env.context.get('website_id')
         if website_id and not \
                 self.env['website'].browse(website_id).is_publisher():
-            html = etree.HTML(res)
+            html = lxml.html.fromstring(res.decode())
             imgs = html.xpath(
                 '//main//img[@src][not(hasclass("lazyload-disable"))]'
             ) + html.xpath(
@@ -32,5 +32,5 @@ class IrUiView(models.Model):
                 src = img.attrib['src']
                 img.attrib['src'] = self.LAZYLOAD_DEFAULT_SRC
                 img.attrib['data-src'] = src
-            res = etree.tostring(html, method='html')
+            res = lxml.etree.tostring(html, method='html', encoding='UTF-8')
         return res

--- a/website_lazy_load_image/models/ir_ui_view.py
+++ b/website_lazy_load_image/models/ir_ui_view.py
@@ -22,7 +22,7 @@ class IrUiView(models.Model):
         website_id = self.env.context.get('website_id')
         if website_id and not \
                 self.env['website'].browse(website_id).is_publisher():
-            html = lxml.html.fromstring(res.decode())
+            html = lxml.html.fromstring(res.decode('UTF-8'))
             imgs = html.xpath(
                 '//main//img[@src][not(hasclass("lazyload-disable"))]'
             ) + html.xpath(

--- a/website_lazy_load_image/tests/test_lazy_load_image.py
+++ b/website_lazy_load_image/tests/test_lazy_load_image.py
@@ -27,7 +27,7 @@ class LazyLoadTest(SavepointCase):
             'arch_base': arch_2,
             'mode': 'primary'
         })
-        arch_3 = 'content not wrapped'
+        arch_3 = '<t t-name="test"><span>content not wrapped</span></t>'
         cls.view_3 = cls.env['ir.ui.view'].create({
             'name': 'Test 3',
             'key': 'website_lazy_load_image.test_3',
@@ -83,13 +83,18 @@ class LazyLoadTest(SavepointCase):
         public_user_id = self.ref('base.public_user')
         ui_view = self.env['ir.ui.view'].sudo(
             public_user_id).with_context(website_id=self.website_id)
-        res = etree.HTML(ui_view.render_template(self.view_3.id))
-        self.assertEqual(res, self.arch_3)
+        res = ui_view.render_template(self.view_3.id).decode('UTF-8')
+        arch = '<span>content not wrapped</span>'
+        self.assertEqual(res, arch)
 
     def test_encoding_render(self):
         """Check content is correctly enconded"""
         public_user_id = self.ref('base.public_user')
         ui_view = self.env['ir.ui.view'].sudo(
             public_user_id).with_context(website_id=self.website_id)
-        res = etree.HTML(ui_view.render_template(self.view_4.id))
-        self.assertEqual(res, self.arch_4)
+        res = ui_view.render_template(self.view_4.id).decode('UTF-8')
+        arch = '<main><span>Teléfono, means phone</span></main>'
+        self.assertEqual(res, arch)
+        robots = self.env.ref('website.robots').render()
+        self.assertNotIn('<html>', robots.decode(
+            'UTF-8'), "Robots must not be wrapped into html DOM")

--- a/website_lazy_load_image/tests/test_lazy_load_image.py
+++ b/website_lazy_load_image/tests/test_lazy_load_image.py
@@ -27,6 +27,23 @@ class LazyLoadTest(SavepointCase):
             'arch_base': arch_2,
             'mode': 'primary'
         })
+        arch_3 = 'content not wrapped'
+        cls.view_3 = cls.env['ir.ui.view'].create({
+            'name': 'Test 3',
+            'key': 'website_lazy_load_image.test_3',
+            'type': 'qweb',
+            'arch_base': arch_3,
+            'mode': 'primary'
+        })
+        arch_4 = ('<t t-name="test"><main><span>Teléfono, means phone'
+                  '</span></main></t>')
+        cls.view_4 = cls.env['ir.ui.view'].create({
+            'name': 'Test 4',
+            'key': 'website_lazy_load_image.test_4',
+            'type': 'qweb',
+            'arch_base': arch_4,
+            'mode': 'primary'
+        })
         cls.website_id = cls.env.ref('website.default_website').id
         cls.default_img = cls.env['ir.ui.view'].LAZYLOAD_DEFAULT_SRC
 
@@ -60,3 +77,19 @@ class LazyLoadTest(SavepointCase):
         imgs = res.xpath('//main//img')
         self.assertTrue('data-src' not in imgs[0].attrib)
         self.assertEqual(imgs[0].attrib['src'], 'hello.jpg')
+
+    def test_no_wrap_content(self):
+        """Check content not be wrapped into extra html tags"""
+        public_user_id = self.ref('base.public_user')
+        ui_view = self.env['ir.ui.view'].sudo(
+            public_user_id).with_context(website_id=self.website_id)
+        res = etree.HTML(ui_view.render_template(self.view_3.id))
+        self.assertEqual(res, self.arch_3)
+
+    def test_encoding_render(self):
+        """Check content is correctly enconded"""
+        public_user_id = self.ref('base.public_user')
+        ui_view = self.env['ir.ui.view'].sudo(
+            public_user_id).with_context(website_id=self.website_id)
+        res = etree.HTML(ui_view.render_template(self.view_4.id))
+        self.assertEqual(res, self.arch_4)


### PR DESCRIPTION
fromstring function.

Before this commit, the render_template has an issue with views retrieved
from a controller, like the wizard of event detail registration, the
the content was introduced into an html DOM, this leads a wrong modal
behavior.

Now the first attempt is with fromstring function if fails, then use
the original process with html function.

Before
![image](https://user-images.githubusercontent.com/10233975/61311122-55b29280-a7bb-11e9-979f-4f3b0b160ad1.png)


After
![image](https://user-images.githubusercontent.com/10233975/61311216-84c90400-a7bb-11e9-9412-71c5ae04830b.png)


Before
![image](https://user-images.githubusercontent.com/10233975/61311665-729b9580-a7bc-11e9-8f07-d1edf2e5e651.png)


After
![image](https://user-images.githubusercontent.com/10233975/61311749-99f26280-a7bc-11e9-921d-2e7546e664c7.png)
