### PR TITLE
[FIX] website_blog_excerpt_img: Remove empty blocks

### DIFF
--- a/website_blog_excerpt_img/templates/blog.xml
+++ b/website_blog_excerpt_img/templates/blog.xml
@@ -19,11 +19,13 @@
                 <div class="col">$0</div>
 
                 <!-- Insert social share thumbnail next to teaser -->
-                <div class="col-5 text-center">
-                    <t t-set="blog_post_meta" t-value="blog_post.get_website_meta()" />
+                <t t-set="blog_post_meta" t-value="blog_post.get_website_meta()" />
+                <div
+                    t-if="blog_post_meta['opengraph_meta']['og:image']"
+                    class="col-5 text-center"
+                >
                     <img
                         class="excerpt-img img-thumbnail"
-                        t-if="blog_post_meta['opengraph_meta']['og:image']"
                         t-att-src="blog_post_meta['opengraph_meta']['og:image']"
                     />
                 </div>


### PR DESCRIPTION
Without this patch, blog posts without image displayed with an ugly empty block. Now they just use the text.

So, it fixes this:

![Captura de pantalla de 2019-07-24 10-55-49](https://user-images.githubusercontent.com/973709/61785712-28419680-ae04-11e9-9fd7-4e1ee31c9e6c.png)

Into this:
![Captura de pantalla de 2019-07-24 10-56-03](https://user-images.githubusercontent.com/973709/61785720-2b3c8700-ae04-11e9-80a8-b6cbf10edea6.png)


@Tecnativa