### PR TITLE
[WIP][10.0][FIX] Try to fix Travis errors, that will color unrelated PR's red.

### DIFF
--- a/website_logo/tests/test_logo.py
+++ b/website_logo/tests/test_logo.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import HttpCase
+from odoo.tools import mute_logger
 from ..controllers.main import Website
 import mock
 
@@ -80,6 +81,7 @@ class TestLogo(HttpCase):
     @mock.patch('%s.http' % imp_cont)
     @mock.patch('%s.StringIO' % imp_cont)
     @mock.patch(imp_req)
+    @mute_logger(imp_cont)
     def test_default_on_exception(self, imp_mk, str_mk, http_mk, func_mk):
         """ It should send the default logo if there is an exception """
         with mock.patch('%s.registry' % imp_cont) as mk:

--- a/website_sale_hide_empty_category/__manifest__.py
+++ b/website_sale_hide_empty_category/__manifest__.py
@@ -13,6 +13,7 @@
     "installable": True,
     "depends": [
         "website_sale",
+        "website_sale_public_pricelist",
     ],
     "data": [
         "views/website_sale_templates.xml",

--- a/website_sale_line_total/__manifest__.py
+++ b/website_sale_line_total/__manifest__.py
@@ -14,6 +14,7 @@
     "depends": [
         "website",
         "website_sale",
+        "website_sale_public_pricelist",
     ],
     "data": [
         "views/website_sale_line_total_view.xml",

--- a/website_sale_public_pricelist/README.rst
+++ b/website_sale_public_pricelist/README.rst
@@ -1,0 +1,37 @@
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
+
+===============================
+Website Sale - Public Pricelist
+===============================
+
+Make sure public user has a valid pricelist
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Ronald Portier <ronald@therp.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_sale_public_pricelist/__init__.py
+++ b/website_sale_public_pricelist/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/website_sale_public_pricelist/__manifest__.py
+++ b/website_sale_public_pricelist/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 - Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Website Sale - Make sure there is a pricelist",
+    "summary": "Hide any Product Categories that are empty",
+    "version": "10.0.0.1.0",
+    "category": "Hidden",
+    "website": "https://github.com/OCA/website",
+    "author": "Therp BV, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website_sale",
+    ],
+    "demo": [
+        "demo/public_user.xml",
+    ],
+}

--- a/website_sale_public_pricelist/demo/public_user.xml
+++ b/website_sale_public_pricelist/demo/public_user.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <function name="_set_public_user_pricelist" model="res.partner" />
+
+</odoo>

--- a/website_sale_public_pricelist/models/__init__.py
+++ b/website_sale_public_pricelist/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import res_partner

--- a/website_sale_public_pricelist/models/res_partner.py
+++ b/website_sale_public_pricelist/models/res_partner.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 - Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def _set_public_user_pricelist(self):
+        """Make sure public user has a pricelist to prevent test failures."""
+        public_user = self.env.ref('base.public_user')
+        pricelist = self.env.ref('product.list0')
+        public_user.write({'property_product_pricelist': pricelist.id})


### PR DESCRIPTION
When submitting another PR I noticed two errors that prevented a succesfull test not related to that PR at all. This will try to solve those errors.

One is supressing an exception message in website_logo. There all the tests succeed, but in the log there is an ERROR message.

And there is this message from Odoo addon website_sale, where I do not quit know where it is coming from. Any help or tips here would be appreciated:
```
2019-07-08 13:52:10,191 7251 INFO openerp_test odoo.addons.website_multi_theme.models.website: Updated multi website theme views for 127.0.0.1: ir.ui.view(994, 995, 996, 997, 998, 999, 1000, 1001, 1003, 1002, 1004, 1005, 1006, 1007, 1009, 1008, 1010, 1011, 1012, 1013, 1014, 1015, 992, 1016, 1017, 1018, 1020, 1019, 993, 1021, 1022, 1023, 1025, 1024, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036)
2019-07-08 13:52:10,744 7251 INFO openerp_test odoo.addons.website_multi_theme.models.website: Updated multi website theme views for 127.0.0.1: ir.ui.view(994, 995, 996, 997, 998, 999, 1000, 1001, 1003, 1002, 1004, 1005, 1006, 1007, 1009, 1008, 1010, 1011, 1012, 1013, 1014, 1015, 992, 1016, 1017, 1018, 1020, 1019, 993, 1021, 1022, 1023, 1025, 1024, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036)
2019-07-08 13:52:10,794 7251 INFO openerp_test odoo.addons.base.ir.ir_http: Generating routing map
2019-07-08 13:52:14,550 7251 ERROR openerp_test odoo.addons.website_sale.models.sale_order: Fail to find pricelist for partner "Public user" (id 5)
2019-07-08 13:52:14,649 7251 INFO openerp_test werkzeug: 127.0.0.1 - - [08/Jul/2019 13:52:14] "GET / HTTP/1.1" 200 -
2019-07-08 13:52:14,657 7251 INFO openerp_test odoo.addons.website_multi_theme.tests.test_assets: test_localhost (odoo.addons.website_multi_theme.tests.test_assets.UICase)
2019-07-08 13:52:14,657 7251 INFO openerp_test odoo.addons.website_multi_theme.tests.test_assets: ` Check localhost downloads its multiwebsite-enabled assets.
```