### PR TITLE
[12.0][FIX] Make it possible to edit pages created by "website_legal_page"

### DIFF
--- a/website_legal_page/views/website_legal.xml
+++ b/website_legal_page/views/website_legal.xml
@@ -10,13 +10,7 @@
         </xpath>
     </template>
 
-
-    <record id="advice" model="ir.ui.view">
-        <field name="name">Legal Advice</field>
-        <field name="type">qweb</field>
-        <field name="key">website.advice</field>
-        <field name="arch" type="xml">
-            <t name="About us" t-name="website.aboutus">
+    <template id="advice" name="Legal Advice">
                 <t t-call="website.layout">
                     <div id="wrap">
                         <div class="oe_structure">
@@ -93,9 +87,7 @@
                         <div class="oe_structure"/>
                     </div>
                 </t>
-            </t>
-        </field>
-    </record>
+    </template>
 
 
     <record id="advise_page" model="website.page">

--- a/website_legal_page/views/website_privacy.xml
+++ b/website_legal_page/views/website_privacy.xml
@@ -12,13 +12,7 @@
         </xpath>
     </template>
 
-
-    <record id="privacy-policy" model="ir.ui.view">
-        <field name="name">Legal Advice</field>
-        <field name="type">qweb</field>
-        <field name="key">website.advice</field>
-        <field name="arch" type="xml">
-            <t name="About us" t-name="website.aboutus">
+    <template id="privacy-policy" name="Privacy Policy">
                 <t t-call="website.layout">
                     <div id="wrap">
                         <div class="oe_structure">
@@ -231,9 +225,7 @@
                         </div>
                     </div>
                 </t>
-            </t>
-        </field>
-    </record>
+    </template>
 
 
     <record id="privacy_page" model="website.page">

--- a/website_legal_page/views/website_terms.xml
+++ b/website_legal_page/views/website_terms.xml
@@ -12,13 +12,7 @@
         </xpath>
     </template>
 
-
-    <record id="terms-of-use" model="ir.ui.view">
-        <field name="name">Legal Advice</field>
-        <field name="type">qweb</field>
-        <field name="key">website.advice</field>
-        <field name="arch" type="xml">
-            <t name="About us" t-name="website.aboutus">
+    <template id="terms-of-use" name="Terms of use">
                 <t t-call="website.layout">
                     <div id="wrap">
                         <div class="oe_structure">
@@ -242,9 +236,7 @@
                         </div>
                     </div>
                 </t>
-            </t>
-        </field>
-    </record>
+    </template>
 
 
     <record id="terms_page" model="website.page">


### PR DESCRIPTION
#### Before this PR:
After installing module 'website_legal_page' we have 3 pages (terms of use, privacy policy, legal advice). When you try to edit all of them, then only (randomly choosen) one (or two) page(s) is editable.

#### After this PR:
All three pages are editable.

#### Migration Notes
If pages introduced by `website_legal_page` addons were modified before this PR, then there is website-specific views exists (in my case only one view) and usualy that views are incorrect. The simple way to fix them is to remove website-specific view(s) and create new-ones that could use correct templates.