### PR TITLE
[FIX] website_crm_recaptcha: Make uninstall work

### DIFF
--- a/website_crm_recaptcha/__init__.py
+++ b/website_crm_recaptcha/__init__.py
@@ -1,1 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from .hooks import uninstall_hook

--- a/website_crm_recaptcha/__manifest__.py
+++ b/website_crm_recaptcha/__manifest__.py
@@ -12,6 +12,7 @@
     "license": "AGPL-3",
     "application": False,
     'installable': True,
+    "uninstall_hook": "uninstall_hook",
     "depends": [
         "website_crm",
         'website_form_recaptcha',

--- a/website_crm_recaptcha/hooks.py
+++ b/website_crm_recaptcha/hooks.py
@@ -1,0 +1,11 @@
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def uninstall_hook(cr, registry):
+    """Unmark crm.lead as recaptcha model."""
+    cr.execute("""
+        UPDATE ir_model
+        SET website_form_recaptcha = FALSE
+        WHERE model = 'crm.lead'
+    """)


### PR DESCRIPTION
Without this patch, after uninstalling the module, all website_crm forms will fail.

@Tecnativa