### PR TITLE
[FIX] website_no_crawler: Revert on uninstall

### DIFF
--- a/website_no_crawler/views/disable_robots.xml
+++ b/website_no_crawler/views/disable_robots.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <template id="website.robots">
+    <template id="robots" inherit_id="website.robots">
+        <xpath expr="." position="replace">
+<t>
 User-agent: *
 Disallow: /
 Sitemap: <t t-esc="url_root"/>sitemap.xml
+</t>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Before this patch, uninstalling the addon didn't revert its behavior.

@Tecnativa TT19451