### PR TITLE
[FIX] website_blog_excerpt_img: Display OG image in latest posts snippet

### DIFF
--- a/website_blog_excerpt_img/__manifest__.py
+++ b/website_blog_excerpt_img/__manifest__.py
@@ -22,5 +22,6 @@
     ],
     "data": [
         "templates/blog.xml",
+        "templates/snippets.xml",
     ],
 }

--- a/website_blog_excerpt_img/templates/snippets.xml
+++ b/website_blog_excerpt_img/templates/snippets.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Tecnativa - Jairo Llopis
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<data>
+
+    <template id="s_latest_posts_list_template" inherit_id="website_blog.s_latest_posts_list_template">
+        <xpath expr="//t[@t-set='cover_properties']" position="attributes">
+            <attribute name="t-value">dict(properties, **{"background-image": "url(%s)" % p.get_website_meta()["opengraph_meta"]["og:image"]})</attribute>
+        </xpath>
+    </template>
+
+</data>


### PR DESCRIPTION
When somebody drags and drops the "Latest Posts - Lists" snippet anywhere in the website, if this module is installed, it is expected to be using the opengraph image, just like the main blog posts list view.

Before:
![Captura de pantalla de 2019-09-26 10-54-31](https://user-images.githubusercontent.com/973709/65680263-88e09000-e04e-11e9-98ad-17b71e19eb62.png)

After:
![Captura de pantalla de 2019-09-26 10-55-10](https://user-images.githubusercontent.com/973709/65680289-90079e00-e04e-11e9-952a-d299a87b9e8e.png)


@Tecnativa TT19639