### PR TITLE
[FIX] website_crm_quick_answer: fix template lang

### DIFF
--- a/website_crm_quick_answer/__manifest__.py
+++ b/website_crm_quick_answer/__manifest__.py
@@ -6,7 +6,7 @@
     'name': "Quick answer for website contact form",
     "summary": "Add an automatic answer for contacts asking for info",
     'category': 'Website',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'website': 'https://github.com/OCA/website',
     'depends': [
         'website_crm',

--- a/website_crm_quick_answer/data/base_automation_data.xml
+++ b/website_crm_quick_answer/data/base_automation_data.xml
@@ -7,7 +7,7 @@
             <field name="model_id" ref="crm.model_crm_lead"/>
             <field name="use_default_to" eval="True"/>
             <field name="email_from">${object.company_id.email}</field>
-            <field name="lang">${object.env.context.get("lang")}</field>
+            <field name="lang">${object.env.context.get("lang") or object.partner_id.lang or object.company_id.lang or object.env.user.lang}</field>
             <field name="subject">Thanks for your request</field>
             <field name="body_html" type="html">
                 <div>Dear <b>${object.partner_id and object.partner_id.name or object.contact_name}</b>,

--- a/website_crm_quick_answer/migrations/12.0.1.1.0/post-migration.py
+++ b/website_crm_quick_answer/migrations/12.0.1.1.0/post-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env):
+    # The template is noupdate=1; force lang update
+    template = env.ref("website_crm_quick_answer.email_template")
+    if template.lang == '${object.env.context.get("lang")}':
+        template.lang = (
+            '${object.env.context.get("lang") or '
+            "object.partner_id.lang or object.company_id.lang or "
+            "object.env.user.lang}"
+        )


### PR DESCRIPTION
The template was always sent in English because under the automation execution there was no lang in context. It's smarter now detecting the language.

@Tecnativa TT21952