### PR TITLE
[FIX] website_form_builder: restore functionality of required & hidden fields

### DIFF
--- a/website_form_builder/__manifest__.py
+++ b/website_form_builder/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Website Form Builder",
     "summary": "Build customized forms in your website",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "category": "Website",
     "website": "https://github.com/OCA/website",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/website_form_builder/migrations/12.0.1.1.0/post-migrate.py
+++ b/website_form_builder/migrations/12.0.1.1.0/post-migrate.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Tecnativa - Jairo Llopis
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from openupgradelib import openupgrade as ou
+from openupgradelib.openupgrade_tools import (
+    convert_html_fragment,
+    convert_html_replacement_class_shortcut as _r,
+)
+
+REPLACEMENTS = (
+    _r(
+        # Use XPath mode because LXML's CSS mode doesn't support `:has()`
+        selector="""
+        //*
+        [hasclass('form-field', 'o_required')]
+        [//input[not(@required)]]
+        """,
+        selector_mode="xpath",
+        class_rm="o_required",
+    ),
+)
+
+
+@ou.migrate()
+def migrate(env, version):
+    """Fix existing form that lost their required behavior.
+
+    Setting fields to required might break existing functionality that passed
+    unnoticed thanks to the bug fixed in this version, so the fix is not
+    requiring the fields, but making them as not required.
+    """
+    candidates = env['ir.ui.view'].search([
+        ("type", "=", "qweb"),
+        ("arch_db", "like", "o_required"),
+    ])
+    for view in candidates:
+        old_arch = view.arch
+        new_arch = convert_html_fragment(old_arch, REPLACEMENTS)
+        if old_arch != new_arch:
+            view.arch = new_arch

--- a/website_form_builder/static/src/js/snippets.js
+++ b/website_form_builder/static/src/js/snippets.js
@@ -99,10 +99,10 @@ odoo.define('website_form_builder.snippets', function (require) {
                 .children("span").prop("contentEditable", true);
         },
 
-        toggleClass: function (type, value) {
+        toggleClass: function (previewMode, value, $li) {
             this._super.apply(this, arguments);
             // Toggle field required attribute to match the container class
-            if (type === "reset" || value === "o_required") {
+            if (previewMode === "reset" || value === "o_required") {
                 this.$inputs.attr(
                     "required",
                     this.$target.hasClass("o_required")
@@ -110,7 +110,7 @@ odoo.define('website_form_builder.snippets', function (require) {
             }
             // Ask for a default value if hiding a field without it
             if (
-                type === "click" &&
+                previewMode === false &&
                 value === "css_non_editable_mode_hidden" &&
                 this.$target.hasClass(value) &&
                 // Query to know if there's a default value
@@ -122,18 +122,18 @@ odoo.define('website_form_builder.snippets', function (require) {
                     "input[value][value!=''],textarea:parent"
                 ).length
             ) {
-                this.ask_default_value(type);
+                this.ask_default_value(previewMode);
             }
         },
 
         /**
          * Prompt the user for a default value for this field.
          *
-         * @param {String} type Event type
+         * @param {String} previewMode Is it in preview mode?
          * @returns {Dialog} Opened dialog
          */
-        ask_default_value: function (type) {
-            if (type === "reset") {
+        ask_default_value: function (previewMode) {
+            if (previewMode === "reset") {
                 // Nothing to reset here
                 return;
             }

--- a/website_form_builder/static/src/js/tour.js
+++ b/website_form_builder/static/src/js/tour.js
@@ -118,8 +118,51 @@ odoo.define("website_form_builder.tour", function (require) {
                     '[data-add_custom_field="selection-radio"]',
             },
             {
-                run: hide_submenus,
                 trigger: ".form-field-selection-radio",
+            },
+            // Add a custom text input
+            {
+                trigger:
+                    ".oe_overlay_options:visible .btn:contains('Customize')",
+            },
+            {
+                trigger:
+                    '.oe_overlay_options:visible a[data-add_custom_field="char"]',
+            },
+            // Make it required
+            {
+                trigger: ".form-field-char[data-optional='true']",
+            },
+            {
+                trigger:
+                    ".oe_overlay_options:visible .btn:contains('Customize')",
+            },
+            {
+                trigger: ".oe_overlay_options:visible a[data-toggle-class='o_required']",
+            },
+            // Make it hidden
+            {
+                run: hide_submenus,
+                trigger: ".form-field-char.o_required[data-optional='true'] input[required]",
+            },
+            {
+                trigger:
+                    ".oe_overlay_options:visible .btn:contains('Customize')",
+            },
+            {
+                trigger: ".oe_overlay_options:visible a:contains('Hide field')",
+            },
+            // Hiding a required field asks user for a default value; fill it
+            {
+                run: "text my default",
+                trigger: ".modal-dialog .o_website_form_input",
+            },
+            {
+                trigger: ".modal-dialog .btn:contains('Save')",
+            },
+            // Remove the custom text field
+            {
+                trigger: ".form-field-char.o_required.css_non_editable_mode_hidden[data-optional='true'] input[required][value='my default']",
             },
             {
                 trigger:

--- a/website_form_builder/templates/snippets.xml
+++ b/website_form_builder/templates/snippets.xml
@@ -101,14 +101,20 @@
             />
 
             <!-- Allow user to set additional required fields -->
-            <div data-selector=".o_website_form_builder .form-field[data-optional=true]">
+            <div
+                data-js="website_form_builder_field"
+                data-selector=".o_website_form_builder .form-field[data-optional=true]"
+            >
                 <a href="#" tabindex="-1" data-toggle-class="o_required" class="dropdown-item">
                     Set as required
                 </a>
             </div>
 
             <!-- Allow to hide fields -->
-            <div data-selector=".o_website_form_builder .form-field">
+            <div
+                data-js="website_form_builder_field"
+                data-selector=".o_website_form_builder .form-field"
+            >
                 <a href="#" tabindex="-1" data-toggle-class="css_non_editable_mode_hidden" class="dropdown-item">
                     <i class="fa fa-eye-slash"/> Hide field
                 </a>


### PR DESCRIPTION
Forward port of #703.

This functionality was lost in v11 migration. Now it is recovered and tested.

What has been recovered:

- Required fields now actually are required.
- When hiding a required field, you are asked for a default value.

A migration script is added, which removes the `o_required` style for forms that were actually not required. This seems to be a safer approach than leaving them looking as required but not being that, or marking them as required and possibly breaking some workflows in forms built with previous bug.

@Tecnativa TT22901