### PR TITLE
[FIX] website_adv_image_optimization: Changes the image selection after changes

### DIFF
--- a/website_adv_image_optimization/static/src/js/website_adv_image_optimization.js
+++ b/website_adv_image_optimization/static/src/js/website_adv_image_optimization.js
@@ -116,7 +116,7 @@ odoo.define('website_adv_image_optimization', function (require) {
                         .records.filter(function (r) {
                             return r.id === attachment_id;
                         });
-                    self.imageDialog._toggleImage(record_data, false, true);
+                    self.imageDialog._toggleImage(record_data[0], false, true);
                 });
             });
         },


### PR DESCRIPTION
Before this commit, when go back to the media dialog after use optimization dialog,  the image loses
the selection focus. With this commit the image doesn't loses the focus.

cc @tecnativa