### PR TITLE
[FIX] website_canonical_url: use website domain

### DIFF
--- a/website_canonical_url/models/website.py
+++ b/website_canonical_url/models/website.py
@@ -35,6 +35,8 @@ class Website(models.Model):
         self.ensure_one()
         if self.canonical_domain:
             return self.canonical_domain
+        if self.domain:
+            return self.domain
         params = self.env['ir.config_parameter'].sudo()
         return params.get_param('web.base.url')
 


### PR DESCRIPTION
It didn't make sense that a website with a specified domain didn't use it as the canonical one by default.

@Tecnativa TT23961