### PR TITLE
[12.0][ADD] website_cache_controller

### DIFF
--- a/website_cache_controller/__init__.py
+++ b/website_cache_controller/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/website_cache_controller/__manifest__.py
+++ b/website_cache_controller/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Website Cache Controller",
+    "summary": "Website Cache Controller",
+    "author": "Odoo Community Association (OCA), Pledra",
+    "website": "http://www.pledra.com",
+    "category": "Website",
+    "license": "AGPL-3",
+    "version": "12.0.1.0.0",
+    "depends": ["website"],
+    "data": [],
+}

--- a/website_cache_controller/controllers/__init__.py
+++ b/website_cache_controller/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/website_cache_controller/controllers/main.py
+++ b/website_cache_controller/controllers/main.py
@@ -1,0 +1,56 @@
+import werkzeug
+from odoo import http
+from odoo.http import request
+from odoo.addons.web.controllers.main import Binary
+
+content_image_route = Binary.content_image.routing.copy()
+content_common_route = Binary.content_common.routing.copy()
+
+image_routes = content_image_route.get('routes', [])
+common_routes = content_common_route.get('routes', [])
+
+content_image_route['routes'] = [
+    r.replace("/web/image", "/website/cache/image") for r in image_routes
+]
+
+content_common_route['routes'] = [
+    r.replace("/web/content", "/website/cache/content") for r in common_routes
+]
+
+
+class WebsiteImageBinary(Binary):
+
+    def proxy_redirect(self, proxy_url, url):
+        """Return proxy redirect if user is internal"""
+        if not request.env.user.has_group('base.group_user'):
+            return False
+        # Redirect to original url for internal users
+        path = request.httprequest.path
+        new_url = path.replace(proxy_url, url)
+        query_string = request.httprequest.query_string
+        if query_string:
+            query_string = query_string.decode("utf-8")
+            new_url = "%s?%s" % (new_url, query_string)
+        return werkzeug.utils.redirect(new_url, code=302)
+
+    @http.route(**content_common_route)
+    def website_content_cache(self, *args, **kw):
+        """Controller designed for serving public assets only and providing a
+        cacheable path for proxy and CDN"""
+        redirect = self.proxy_redirect(
+            '/website/cache/content', '/web/content'
+        )
+        if redirect:
+            return redirect
+        return self.content_common(*args, **kw)
+
+    @http.route(**content_image_route)
+    def website_cache_image(self, *args, **kw):
+        """Controller designed for serving public images only and providing a
+        cacheable path for proxy and CDN"""
+        redirect = self.proxy_redirect(
+            '/website/cache/image', '/web/image'
+        )
+        if redirect:
+            return redirect
+        return self.content_image(*args, **kw)

--- a/website_cache_controller/models/__init__.py
+++ b/website_cache_controller/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_ui_view
+from . import assets_bundle

--- a/website_cache_controller/models/assets_bundle.py
+++ b/website_cache_controller/models/assets_bundle.py
@@ -1,0 +1,13 @@
+from odoo.addons.base.models.assetsbundle import AssetsBundle
+
+get_asset_template_url = AssetsBundle._get_asset_template_url
+
+
+def _get_asset_template_url(self):
+    """Monkeypatch method to use cacheable path for frontend assets"""
+    return get_asset_template_url(self).replace(
+        '/web/content', '/website/cache/content'
+    )
+
+
+AssetsBundle._get_asset_template_url = _get_asset_template_url

--- a/website_cache_controller/models/ir_ui_view.py
+++ b/website_cache_controller/models/ir_ui_view.py
@@ -1,0 +1,61 @@
+import lxml
+
+from odoo import api, models
+
+
+class IrUiView(models.Model):
+    _inherit = "ir.ui.view"
+
+    def get_html_from_string(self, res, full_html=None):
+        """Get lxml etree object from string (complete or partial)"""
+        if full_html:
+            html = lxml.html.fromstring(res)
+        else:
+            html = lxml.html.document_fromstring(res)[0]
+        return html
+
+    def get_cache_paths_view(self, res):
+        """Return an altered view by replacing public images paths from
+        '/web/image/X' to '/website/cache/image/X'"""
+
+        website_id = self.env.context.get("website_id")
+
+        # Cache path destined for frontend and public/portal users only
+        if not website_id:
+            return res
+
+        full_html = lxml.html._looks_like_full_html_bytes(res)
+
+        try:
+            html = self.get_html_from_string(res.decode('UTF-8'), full_html)
+        except ValueError:
+            html = self.get_html_from_string(res, full_html)
+        except Exception:
+            return res
+
+        # Replace occurances of /web/image only inside attributes
+        elements = html.xpath(
+            "//*[attribute::*[contains(., '/web/image/')]]"
+        )
+
+        if not elements:
+            return res
+
+        for el in elements:
+            cache_attrs = {
+                k: v.replace('/web/image', '/website/cache/image')
+                for k, v in el.attrib.items() if '/web/image' in v
+            }
+            el.attrib.update(cache_attrs)
+
+        html = lxml.etree.tostring(html, method='html', encoding='UTF-8')
+
+        return html
+
+    @api.multi
+    def render(self, values=None, engine='ir.qweb', minimal_qcontext=False):
+        res = super(IrUiView, self).render(
+            values=values, engine=engine, minimal_qcontext=minimal_qcontext
+        )
+        res = self.get_cache_paths_view(res)
+        return res


### PR DESCRIPTION
First off I am not sure if there is a similar solution or a better approach to this problem. I couldn't find one so I thought it was easier to propose the module and explain the issue alongside it.

The problem:

Odoo website snippets and frontend content makes extensive use of the /web/image controller to display image resources, almost all snippets of manually added content (not products or product categories) use this.

At the same time the backend uses this controller as well for images that are private (customer images, mrp / workorder images etc etc). Using a cache on this path (/web/image) would be really unsafe as they would be captured by the relevant proxy / cdn from an authenticated user and served to anyone requesting that link. This does not happen if the request goes through odoo as access rules are being checked with each request.

Proposed solution:

The only way I could think of safely caching such images and distinguishing them from the rest of the private ones was to use a new path specifically for cacheable content and serving data only when it is public to avoid the capture of any potential proxys and/or cdns. Thus taking inspiration from the website_lazy_load module a replace is done for non-internal users (including crawlers) from /web/image/ to /website/cache/image.

A second layer of safety was added in the /website/cache/image controller where another check is done and a redirect is made in case the user (for some reason) would manually change the url. This can also happen with website/image controller as well btw.

Hope this makes some sense and if not I am curious to see what the proper approach would be.