### PR TITLE
[12.0][ADD] website_js_below_the_fold_payment

### DIFF
--- a/website_js_below_the_fold_payment/__manifest__.py
+++ b/website_js_below_the_fold_payment/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Website JS Below The Fold Payment',
+    'category': 'Website',
+    'version': '12.0.1.0.0',
+    'author': 'Druidoo, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'website': 'https://github.com/OCA/website',
+    'depends': [
+        'website_js_below_the_fold',
+        'payment',
+    ],
+    'data': [
+        'templates/templates.xml'
+    ],
+    'auto_install': True,
+}

--- a/website_js_below_the_fold_payment/readme/CONTRIBUTORS.rst
+++ b/website_js_below_the_fold_payment/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/website_js_below_the_fold_payment/readme/DESCRIPTION.rst
+++ b/website_js_below_the_fold_payment/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This is a technical module to fix a compatibility issue between
+`website_js_below_the_fold` and `payment` modules.
+
+Issue description: https://github.com/OCA/website/issues/587

--- a/website_js_below_the_fold_payment/readme/ROADMAP.rst
+++ b/website_js_below_the_fold_payment/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+This module is not required in `13.0`, and shouldn't be migrated.
+Odoo removed the embebed js in this view.

--- a/website_js_below_the_fold_payment/templates/templates.xml
+++ b/website_js_below_the_fold_payment/templates/templates.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- 
+        Fix for website_js_below_the_fold module
+        https://github.com/OCA/website/issues/587#issuecomment-487985544 
+        Credits to https://github.com/go4site
+    -->
+    <template id="payment_page_fix" inherit_id="payment.payment_process_page">
+        <xpath expr="//script" position="replace">
+            <script>
+                document.addEventListener("DOMContentLoaded", function(event) {
+                    odoo.define('payment.processing_bootstrap', function(require) {
+                        var PaymentProcessing = require('payment.processing');
+                        var processingWidget = new PaymentProcessing(null, <t t-esc="payment_tx_ids"/>);
+                        processingWidget.attachTo($('.o_payment_processing'));
+                    });
+                });
+           </script>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This is a technical module to fix a compatibility issue between `website_js_below_the_fold` and `payment` modules.

References:

- https://github.com/OCA/website/issues/587
- https://github.com/OCA/website/issues/648
- https://github.com/OCA/website/issues/587#issuecomment-487985544

