### PR TITLE
[11.0][IMP] website_cookie_notice: remove not needed query

### DIFF
--- a/website_cookie_notice/controllers/main.py
+++ b/website_cookie_notice/controllers/main.py
@@ -12,7 +12,5 @@ class CookieNotice(http.Controller):
     def accept_cookies(self):
         """Stop spamming with cookie banner."""
         http.request.session["accepted_cookies"] = True
-        http.request.env['ir.ui.view'].search([
-            ('type', '=', 'qweb')
-        ]).clear_caches()
+        http.request.env['ir.ui.view'].clear_caches()
         return {'result': 'ok'}


### PR DESCRIPTION
The clear_caches method of models is a class method, then I would say is not related to specific records. The controller is generating a query which is not actually needed, at least in Odoo version 11.0 code.