### PR TITLE
[FIX] website_form_builder: duplicate radio and checkbox options

### DIFF
--- a/website_form_builder/templates/snippets.xml
+++ b/website_form_builder/templates/snippets.xml
@@ -92,12 +92,8 @@
                 data-drop-in=".o_website_form_builder .o_website_form_fields"
             />
             <div
-                data-selector=".o_website_form_builder .form-field .checkbox"
-                data-drop-near=".o_website_form_builder .form-field .checkbox"
-            />
-            <div
-                data-selector=".o_website_form_builder .form-field .radio"
-                data-drop-near=".o_website_form_builder .form-field .radio"
+                data-selector=".o_website_form_builder .form-field .form-check"
+                data-drop-near=".o_website_form_builder .form-field .form-check"
             />
 
             <!-- Allow user to set additional required fields -->


### PR DESCRIPTION
Fix a regression from #741 where custom radio and checkbox options couldn't be duplicated anymore.

| Before | After |
| --- | --- |
| ![mal](https://user-images.githubusercontent.com/973709/88367403-f141f000-cd8b-11ea-8663-6d8a6377b4ae.gif) | ![bien](https://user-images.githubusercontent.com/973709/88367396-ef782c80-cd8b-11ea-8f25-8db57f8c93ea.gif) |



@Tecnativa TT24837