### PR TITLE
[FIX] website_snippet_anchor: use correct assets

### DIFF
--- a/website_snippet_anchor/templates/assets.xml
+++ b/website_snippet_anchor/templates/assets.xml
@@ -4,7 +4,7 @@
 
 <odoo>
 
-<template id="assets_editor" inherit_id="web_editor.assets_editor">
+<template id="assets_editor" inherit_id="website.assets_editor">
     <xpath expr="." position="inside">
         <script type="text/javascript"
                 src="/website_snippet_anchor/static/src/js/anchor_option.js"/>


### PR DESCRIPTION
`web_editor.assets_editor` is used in the backend too, where this module has no use and logs a dependency error on `website.utils` (which is only available in the website).

Switching to `website.assets_editor` will reduce the payload on the backend and remove that warning.

@Tecnativa