### PR TITLE
[FIX] website_legal_page: better visualization as required checkbox label

### DIFF
--- a/website_legal_page/views/reusable_templates.xml
+++ b/website_legal_page/views/reusable_templates.xml
@@ -3,9 +3,9 @@
     <!-- Base templates for submodules -->
     <template id="acceptance_full">
         <span class="acceptance_full">
-            <a
+            I accept <a
                 href="/legal"
-            >I accept the legal terms, the privacy policy &amp; conditions of this website.</a>
+            >the legal terms, the privacy policy &amp; conditions</a> of this website.
         </span>
     </template>
 </odoo>


### PR DESCRIPTION
cc @Tecnativa TT25963
@pedrobaeza @Tardo Could you review?

When this template is used as a label for a required checkbox and the user doesn't check it before the form is submitted, then this is how it currently looks:

![image](https://user-images.githubusercontent.com/38267832/95365443-21376480-08a0-11eb-9fbe-2f7a73f1e28b.png)


 and this is how I propose it to look in those cases:

![image](https://user-images.githubusercontent.com/38267832/95365536-4a57f500-08a0-11eb-859a-5c86b1409632.png)

