### PR TITLE
[FIX] Remove google_tag_manager_key required attribute (no longer necessary)

### DIFF
--- a/website_google_tag_manager/views/res_config_settings_view.xml
+++ b/website_google_tag_manager/views/res_config_settings_view.xml
@@ -19,8 +19,7 @@
                         <div class="content-group">
                             <div class="row mt16">
                                 <label class="col-md-4 o_light_label" for="google_tag_manager_key"/>
-                                <field name="google_tag_manager_key" placeholder="GTM-XXXXX"
-                                       attrs="{'required': [('google_management_client_id', '!=', False)]}"/>
+                                <field name="google_tag_manager_key" placeholder="GTM-XXXXX"/>
                             </div>
                         </div>
 


### PR DESCRIPTION
See 12.0 https://github.com/OCA/website/blob/12.0/website_google_tag_manager/views/res_config_settings_view.xml#L23