### PR TITLE
[12.0][FIX] website_lazy_load_image: reintroduce missing doctype when recreating html

### DIFF
--- a/website_lazy_load_image/models/ir_ui_view.py
+++ b/website_lazy_load_image/models/ir_ui_view.py
@@ -23,6 +23,7 @@ class IrUiView(models.Model):
         if website_id and not \
                 self.env['website'].browse(website_id).is_publisher():
             html = lxml.html.fromstring(res.decode('UTF-8'))
+            doctype = html.getroottree().docinfo.doctype
             imgs = html.xpath(
                 '//main//img[@src][not(hasclass("lazyload-disable"))]'
             ) + html.xpath(
@@ -32,5 +33,7 @@ class IrUiView(models.Model):
                 src = img.attrib['src']
                 img.attrib['src'] = self.LAZYLOAD_DEFAULT_SRC
                 img.attrib['data-src'] = src
-            res = lxml.etree.tostring(html, method='html', encoding='UTF-8')
+            res = lxml.html.etree.tostring(
+                html, method='html', encoding='UTF-8', doctype=doctype
+            )
         return res


### PR DESCRIPTION
This fix reintroduce the missing doctype when the html is recreated by the `lxml` parser.
When `website_lazy_load_image` module is installed, the `<!DOCTYPE html>` is no more set as a header.
It was reported in https://github.com/odoo/odoo/issues/44612

This issue can only by seen by a non-logged user, probably because when logged, an editor module is fixing this issue as a side-effect.

A backport fix for 11.0 will be necessary.