### PR TITLE
[FIX] website_crm_quick_answer: migration signature

### DIFF
--- a/website_crm_quick_answer/migrations/12.0.1.1.0/post-migration.py
+++ b/website_crm_quick_answer/migrations/12.0.1.1.0/post-migration.py
@@ -4,7 +4,7 @@ from openupgradelib import openupgrade
 
 
 @openupgrade.migrate(use_env=True)
-def migrate(env):
+def migrate(env, version):
     # The template is noupdate=1; force lang update
     template = env.ref("website_crm_quick_answer.email_template")
     if template.lang == '${object.env.context.get("lang")}':


### PR DESCRIPTION
This was failing with:

```
website_crm_quick_answer: Running migration [12.0.1.1.0>] post-migration
2021-02-03 10:00:47,140 1 INFO prod OpenUpgrade: website_crm_quick_answer: post-migration script called with version 12.0.1.0.0
2021-02-03 10:00:47,140 1 ERROR prod OpenUpgrade: website_crm_quick_answer: error in migration script website_crm_quick_answer/migrations/12.0.1.1.0/post-migration.py: migrate() takes 1 positional argument but 2 were given
2021-02-03 10:00:47,140 1 ERROR prod OpenUpgrade: migrate() takes 1 positional argument but 2 were given
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/openupgradelib/openupgrade.py", line 1873, in wrapped_function
    if use_env2 else cr, version)
TypeError: migrate() takes 1 positional argument but 2 were given
2021-02-03 10:00:47,144 1 WARNING prod odoo.modules.loading: Transient module states were reset
2021-02-03 10:00:47,150 1 ERROR prod odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 86, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 417, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 313, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 227, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/opt/odoo/custom/src/odoo/odoo/modules/migration.py", line 190, in migrate_module
    migrate(self.cr, installed_version)
  File "/usr/local/lib/python3.5/site-packages/openupgradelib/openupgrade.py", line 1873, in wrapped_function
    if use_env2 else cr, version)
TypeError: migrate() takes 1 positional argument but 2 were given
2021-02-03 10:00:47,151 1 ERROR prod click_odoo.env_options: exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/click_odoo/env_options.py", line 211, in _invoke
    database=database, rollback=rollback, ctx=ctx
  File "/usr/local/lib/python3.5/contextlib.py", line 59, in __enter__
    return next(self.gen)
  File "/usr/local/lib/python3.5/site-packages/click_odoo_contrib/update.py", line 272, in OdooEnvironmentWithUpdate
    ignore_addons,
  File "/usr/local/lib/python3.5/site-packages/click_odoo_contrib/update.py", line 244, in _update_db
    ignore_addons,
  File "/usr/local/lib/python3.5/site-packages/click_odoo_contrib/update.py", line 215, in _update_db_nolock
    Registry.new(database, update_module=True)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 86, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 417, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 313, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 227, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/opt/odoo/custom/src/odoo/odoo/modules/migration.py", line 190, in migrate_module
    migrate(self.cr, installed_version)
  File "/usr/local/lib/python3.5/site-packages/openupgradelib/openupgrade.py", line 1873, in wrapped_function
    if use_env2 else cr, version)
TypeError: migrate() takes 1 positional argument but 2 were given
Error: migrate() takes 1 positional argument but 2 were given
```

@Tecnativa TT21952