### PR TITLE
[FIX] website_no_crawler: robots.txt should not be translated

### DIFF
--- a/website_no_crawler/i18n/es.po
+++ b/website_no_crawler/i18n/es.po
@@ -21,10 +21,9 @@ msgstr ""
 msgid "User-agent: *\n"
 "Disallow: /\n"
 "Sitemap:"
-msgstr ""
-"Agente de usuario: *\n"
-"No permitir: /\n"
-"Mapa del sitio:"
+msgstr "User-agent: *\n"
+"Disallow: /\n"
+"Sitemap:"
 
 #. module: website_no_crawler
 #: model_terms:ir.ui.view,arch_db:website_no_crawler.robots


### PR DESCRIPTION
robots.txt should not be translated

It was translated from weblate.

@claudiagn check it

Is there any mechanism to prevent weblate from translating it?