### PR TITLE
[FIX] website_form_recaptcha: make clear that only v2 is supported

### DIFF
--- a/website_form_recaptcha/readme/CONFIGURE.rst
+++ b/website_form_recaptcha/readme/CONFIGURE.rst
@@ -1,5 +1,5 @@
 First of all you must obtain
-a ReCaptcha key from `Google <http://www.google.com/recaptcha/admin>`_
+a ReCaptcha v2 key from `Google <http://www.google.com/recaptcha/admin>`_
 
 **Global setup**
 

--- a/website_form_recaptcha/views/website_config_settings.xml
+++ b/website_form_recaptcha/views/website_config_settings.xml
@@ -21,7 +21,7 @@
                         <label for="has_google_recaptcha" string="reCaptcha"/>
                         <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
                         <div class="text-muted mt8">
-                           Protect your forms using reCaptcha control.
+                           Protect your forms using reCaptcha v2 control.
                         </div>
                         <div class="content-group" attrs="{'invisible': [('has_google_recaptcha', '=', False)]}">
                             <div class="row mt16">
@@ -34,7 +34,7 @@
 
                         <div attrs="{'invisible': [('has_google_recaptcha', '=', False)]}" class="mt8">
                             <a role="button" class="btn-link" target="_blank" href="http://www.google.com/recaptcha/admin"><i class="fa fa-arrow-right"></i>
-                            How to get my reCaptcha Key
+                            How to get my reCaptcha v2 Key
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
Without this message, it's normal that the user decides to obtain a recaptcha v3 key pair, but that won't work.

@Tecnativa TT31295