### PR TITLE
[FIX] website_cookie_notice: do not hide menu

### DIFF
--- a/website_cookie_notice/static/src/css/cookies.scss
+++ b/website_cookie_notice/static/src/css/cookies.scss
@@ -1,4 +1,0 @@
-.cc-cookies {
-    position: fixed;
-    z-index: 1100;
-}

--- a/website_cookie_notice/views/assets.xml
+++ b/website_cookie_notice/views/assets.xml
@@ -6,10 +6,6 @@
         inherit_id="web.assets_frontend"
     >
         <xpath expr="." position="inside">
-            <link
-                rel="stylesheet"
-                href="/website_cookie_notice/static/src/css/cookies.scss"
-            />
             <script
                 type="text/javascript"
                 src="/website_cookie_notice/static/src/js/accept_cookies.js"


### PR DESCRIPTION
Before this patch, the cookie message rendered the website menu useless.

Before: 
![Screenshot 2021-09-24 at 09-22-03 Home My Website](https://user-images.githubusercontent.com/973709/134643198-2e6c8bcd-2c42-43dd-b507-3728fe5b392d.png)



After: ![Screenshot 2021-09-24 at 09-24-11 Home My Website](https://user-images.githubusercontent.com/973709/134643217-555e2475-cb2e-4cf6-b0a9-5e95664377d8.png)

@Tecnativa TT32061