### PR TITLE
[ADD][13.0] Web Core Vitals: Critical CSS (for FCP/LCP improvement)

### DIFF
--- a/setup/website_critical_css/odoo/addons/website_critical_css
+++ b/setup/website_critical_css/odoo/addons/website_critical_css
@@ -1,0 +1,1 @@
+../../../../website_critical_css

--- a/setup/website_critical_css/setup.py
+++ b/setup/website_critical_css/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_critical_css/__init__.py
+++ b/website_critical_css/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/website_critical_css/__manifest__.py
+++ b/website_critical_css/__manifest__.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Website Critical CSS",
+    "version": "13.0.1.0.0",
+    "author": "Sunflower IT,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Website",
+    "summary": "Website Critical CSS to improve FCP score",
+    "depends": ["website"],
+    "data": ["views/website_page.xml", "views/templates.xml"],
+    "installable": True,
+}

--- a/website_critical_css/models/__init__.py
+++ b/website_critical_css/models/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import website_page
+from . import ir_qweb

--- a/website_critical_css/models/ir_qweb.py
+++ b/website_critical_css/models/ir_qweb.py
@@ -1,0 +1,77 @@
+from odoo import models
+
+from odoo.addons.website.models.ir_qweb import AssetsBundleMultiWebsite
+
+
+class AssetsBundleCriticalCSS(AssetsBundleMultiWebsite):
+    def to_node(
+        self,
+        css=True,
+        js=True,
+        debug=False,
+        async_load=False,
+        defer_load=False,
+        lazy_load=False,
+    ):
+        response = super(AssetsBundleCriticalCSS, self).to_node(
+            css=css,
+            js=js,
+            debug=debug,
+            async_load=async_load,
+            defer_load=defer_load,
+            lazy_load=lazy_load,
+        )
+        if not (css and defer_load):
+            return response
+        new_response = []
+        for item in response:
+            if not (item and item[0] == "link"):
+                new_response.append(item)
+            else:
+                attr = item[1]
+                attr["media"] = "print"
+                attr["onload"] = "this.media='all'"
+                new_response.append(("link", attr, None))
+        return new_response
+
+
+class IrQWeb(models.AbstractModel):
+    _inherit = "ir.qweb"
+
+    def get_asset_bundle(self, xmlid, files, env=None):
+        return AssetsBundleCriticalCSS(xmlid, files, env=env)
+
+    def _get_asset_nodes(
+        self,
+        xmlid,
+        options,
+        css=True,
+        js=True,
+        debug=False,
+        async_load=False,
+        defer_load=False,
+        lazy_load=False,
+        values=None,
+    ):
+        has_critical_css = bool(
+            css
+            and isinstance(values, dict)
+            and values.get("main_object")
+            and values["main_object"]._name == "website.page"
+            and values["main_object"].critical_css
+        )
+        # toggle defer_load to True in case of css=True and has_critical_css.
+        # In core, defer_load is only in use for JS currently,
+        # so we can use it for CSS in order to bust tools.ormcache cache, instead
+        # of trying to override the tools.ormcache dependency.
+        return super(IrQWeb, self)._get_asset_nodes(
+            xmlid,
+            options,
+            css=css,
+            js=js,
+            debug=debug,
+            async_load=async_load,
+            defer_load=defer_load or has_critical_css,
+            lazy_load=lazy_load,
+            values=values,
+        )

--- a/website_critical_css/models/ir_qweb.py
+++ b/website_critical_css/models/ir_qweb.py
@@ -59,6 +59,7 @@ class IrQWeb(models.AbstractModel):
             and values.get("main_object")
             and values["main_object"]._name == "website.page"
             and values["main_object"].critical_css
+            and not self.env.user.has_group("website.group_website_designer")
         )
         # toggle defer_load to True in case of css=True and has_critical_css.
         # In core, defer_load is only in use for JS currently,

--- a/website_critical_css/models/website_page.py
+++ b/website_critical_css/models/website_page.py
@@ -1,4 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import re
+
 from odoo import api, fields, models
 
 
@@ -26,7 +28,9 @@ class WebsitePage(models.Model):
 
     def write(self, vals):
         if "critical_css" in vals:
-            css = vals.get("critical_css")
-            css = css.replace("<style>", "").replace("</style>", "")
-            vals["critical_css"] = css
+            # strip wrapping spaces or style tags
+            css = (vals.get("critical_css") or "").strip()
+            lstrip = re.compile(r"^<\s*style\s*>\s*", re.IGNORECASE)
+            rstrip = re.compile(r"\s*<\s*style\s*>$", re.IGNORECASE)
+            vals["critical_css"] = re.sub(lstrip, "", re.sub(rstrip, "", css)) or None
         return super(WebsitePage, self).write(vals)

--- a/website_critical_css/models/website_page.py
+++ b/website_critical_css/models/website_page.py
@@ -1,0 +1,32 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class WebsitePage(models.Model):
+    _inherit = "website.page"
+
+    critical_css = fields.Text("Critical CSS")
+
+    @api.model
+    def get_page_info(self, id):
+        return self.browse(id).read(
+            [
+                "id",
+                "name",
+                "url",
+                "website_published",
+                "website_indexed",
+                "date_publish",
+                "menu_ids",
+                "is_homepage",
+                "website_id",
+                "critical_css",
+            ],
+        )
+
+    def write(self, vals):
+        if "critical_css" in vals:
+            css = vals.get("critical_css")
+            css = css.replace("<style>", "").replace("</style>", "")
+            vals["critical_css"] = css
+        return super(WebsitePage, self).write(vals)

--- a/website_critical_css/readme/CONTRIBUTORS.rst
+++ b/website_critical_css/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Dan Kiplangat <dan@sunflowerweb.nl>
+* Tom Blauwendraat <tom@sunflowerweb.nl>

--- a/website_critical_css/readme/DESCRIPTION.rst
+++ b/website_critical_css/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module can improve the Google PageSpeed score of individual website pages.
+
+In particular, it improves the score for First Contentful Paint (FCP). It does so
+by allowing to configure a blob of 'Critical CSS' for each page, which is the only
+CSS that will be loaded before first paint. Any other CSS is delayed.

--- a/website_critical_css/readme/ROADMAP.rst
+++ b/website_critical_css/readme/ROADMAP.rst
@@ -1,0 +1,4 @@
+* Support automatic critical CSS generation when page layout is
+  changed, when the `critical` tool is installed on server.
+* Investigate possible incompatibility with `web_company_color`
+  Both are overriding the same function in `ir.qweb`

--- a/website_critical_css/readme/USAGE.rst
+++ b/website_critical_css/readme/USAGE.rst
@@ -1,0 +1,18 @@
+To use this module:
+
+  * Go to Website -> Pages and select a page to optimize
+  * Clear out any current contents of the 'Critical CSS' field
+  * Find out the public facing URL of this page
+  * Generate Critical CSS for this URL while selecting the right widths for
+    Desktop and Mobile views
+  * Paste the blob in the 'Critical CSS' field.
+
+To generate critical CSS you have a couple of options:
+
+  * Use a free online Critical CSS generator. At the time of writing
+    there are: Sitelocity, Pegasaas, web.dev, Corewebvitals.io, ...
+  * Install the npm [critical](https://github.com/addyosmani/critical)
+    package and generate it on your local.
+
+To test improvement of FCP score, use for example Lighthouse, which is
+build into Chrome browser.

--- a/website_critical_css/static/src/js/page_properties.js
+++ b/website_critical_css/static/src/js/page_properties.js
@@ -1,0 +1,25 @@
+odoo.define("website_critical_css.page_properties", function(require) {
+    "use strict";
+
+    var contentMenu = require("website.contentMenu");
+    var PagePropertiesDialog = contentMenu.PagePropertiesDialog;
+
+    PagePropertiesDialog.include({
+        xmlDependencies: PagePropertiesDialog.prototype.xmlDependencies.concat([
+            "/website_critical_css/static/src/xml/page_properties.xml",
+        ]),
+
+        save: function() {
+            var values = {
+                critical_css: this.$("#critical_css").val(),
+            };
+            this._rpc({
+                model: "website.page",
+                method: "write",
+                args: [[this.page_id], values],
+            });
+
+            return this._super.apply(this, arguments);
+        },
+    });
+});

--- a/website_critical_css/static/src/xml/page_properties.xml
+++ b/website_critical_css/static/src/xml/page_properties.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template>
+    <t t-extend="website.pagesMenu.page_info">
+        <t t-jquery="ul li:last-child" t-operation="after">
+            <li class="nav-item">
+                <a
+                    aria-controls="critical_css"
+                    role="tab"
+                    data-toggle="tab"
+                    class="nav-link"
+                    href="#critical_css_tab"
+                >Critical CSS</a>
+            </li>
+        </t>
+        <t t-jquery="#advances_page_info" t-operation="after">
+            <div role="tabpanel" id="critical_css_tab" class="tab-pane fade">
+                <div class="form-group row">
+                    <textarea
+                        class="form-control"
+                        id="critical_css"
+                        style="min-height: 200px"
+                    >
+                        <t t-if="widget.page.critical_css">
+                            <t t-esc="widget.page.critical_css" />
+                        </t>
+                    </textarea>
+                </div>
+            </div>
+        </t>
+    </t>
+</template>

--- a/website_critical_css/static/src/xml/page_properties.xml
+++ b/website_critical_css/static/src/xml/page_properties.xml
@@ -20,9 +20,7 @@
                         id="critical_css"
                         style="min-height: 200px"
                     >
-                        <t t-if="widget.page.critical_css">
-                            <t t-esc="widget.page.critical_css" />
-                        </t>
+                        <t t-esc="widget.page.critical_css or ''" />
                     </textarea>
                 </div>
             </div>

--- a/website_critical_css/views/templates.xml
+++ b/website_critical_css/views/templates.xml
@@ -1,0 +1,25 @@
+<odoo>
+    <template id="assets_editor" inherit_id="website.assets_editor">
+        <xpath expr=".">
+            <script
+                type="text/javascript"
+                src="/website_critical_css/static/src/js/page_properties.js"
+            />
+        </xpath>
+    </template>
+    <template
+        id="add_critical_css"
+        inherit_id="website.user_navbar"
+        name="Add Critical CSS"
+    >
+        <xpath expr="//head/*[1]" position="before">
+            <t
+                t-if="main_object and main_object._name == 'website.page' and main_object.critical_css"
+            >
+                <style>
+                    <t t-raw="main_object.critical_css" />
+                </style>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/website_critical_css/views/website_page.xml
+++ b/website_critical_css/views/website_page.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_website_pages_form" model="ir.ui.view">
+        <field name="model">website.page</field>
+        <field name="inherit_id" ref="website.website_pages_form_view" />
+        <field name="arch" type="xml">
+            <field name="menu_ids" position="after">
+                <group>
+                    <field name="critical_css" />
+                </group>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module can improve the Google PageSpeed score of individual website pages.

In particular, it improves the score for First Contentful Paint (FCP). It does so
by allowing to configure a blob of 'Critical CSS' for each page, which is the only
CSS that will be loaded before first paint. Any other CSS is delayed.

To use this module:

  * Go to Website -> Pages and select a page to optimize
  * Find out the public facing URL of this page
  * Generate Critical CSS for this URL
  * Paste the blob in the 'Critical CSS' field.

To generate critical CSS you have a couple of options:

  * Use a free online Critical CSS generator. At the time of writing
    there are: Sitelocity, Pegasaas, web.dev, Corewebvitals.io, ...
  * Install the npm [critical](https://github.com/addyosmani/critical)
    package and generate it on your local.

To test improvement of FCP score, use for example Lighthouse, which is
build into Chrome browser.