### PR TITLE
[13.0][ADD] Matomo Tag Manager 

### DIFF
--- a/website_matomo_tag_manager/__init__.py
+++ b/website_matomo_tag_manager/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/website_matomo_tag_manager/__manifest__.py
+++ b/website_matomo_tag_manager/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Website Matomo Tag Manager',
+    'category': 'Website',
+    'version': '13.0.1.0.0',
+    'author': 'Onestein',
+    'depends': [
+        'website',
+    ],
+    'data': [
+        'views/website.xml',
+        'views/website_config_settings.xml',
+        'templates/website.xml',
+    ]
+}

--- a/website_matomo_tag_manager/models/__init__.py
+++ b/website_matomo_tag_manager/models/__init__.py
@@ -1,0 +1,2 @@
+from . import website
+from . import website_config_settings

--- a/website_matomo_tag_manager/models/website.py
+++ b/website_matomo_tag_manager/models/website.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Onestein (<https://www.onestein.nl>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    matomo_tag_manager = fields.Boolean(string='Matomo Tag Manager')
+    matomo_host_name = fields.Char("Matomo Host")
+    matomo_container_ref = fields.Char("Matomo Container ID")
+
+    def _matomo_tag_manager_script(self):
+        self.ensure_one()
+        res = '''
+            var _mtm = window._mtm = window._mtm || [];
+            _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')
+            [0];
+            g.type='text/javascript'; g.async=true;
+            g.src='https://%s/js/container_%s.js';
+            s.parentNode.insertBefore(g,s);
+        ''' % (self.matomo_host_name, self.matomo_container_ref)
+        return res

--- a/website_matomo_tag_manager/models/website_config_settings.py
+++ b/website_matomo_tag_manager/models/website_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    matomo_tag_manager = fields.Boolean("Matomo Tag Manager", related="website_id.matomo_tag_manager", readonly=False)
+    matomo_host_name = fields.Char(string="Matomo Host", related="website_id.matomo_host_name", readonly=False)
+    matomo_container_ref = fields.Char(string="Matomo Container ID", related="website_id.matomo_container_ref", readonly=False)

--- a/website_matomo_tag_manager/readme/CONTRIBUTORS.rst
+++ b/website_matomo_tag_manager/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Antonio Esposito <e.esposito@onestein.nl>
+* Renée Duijzers <r.duijzers@onestein.nl>

--- a/website_matomo_tag_manager/readme/DESCRIPTION.rst
+++ b/website_matomo_tag_manager/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module introduces the Matomo Tag Manager JS script on all the website pages.
+For all websites selected by the user settings/website (front-end) or website/configuration/websites.
+The JS script gets inserted in the head of each page as first script, as desired by Matomo for analysis.

--- a/website_matomo_tag_manager/readme/USAGE.rst
+++ b/website_matomo_tag_manager/readme/USAGE.rst
@@ -1,0 +1,9 @@
+To use this module, activate the Matomo Tag Manager in settings or configuration for each website:
+
+* Go to Website -> Configuration -> Websites (back-end)
+* Or Go to Settings -> Website (front-end)
+* Select a (or create a new) website
+* Flag the checkbox "Matomo Tag Manager"
+* Fill in your personal Matomo credentials
+* The script will be placed as first script in the head of each page
+* The requested data will be send to Matomo for analysis

--- a/website_matomo_tag_manager/templates/website.xml
+++ b/website_matomo_tag_manager/templates/website.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2020 Onestein (<https://www.onestein.nl>)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <template id="website_layout" inherit_id="website.layout">
+        <xpath expr="//head/script[1]" position="before">
+
+            <!-- Matomo Tag Manager -->
+            <t t-if="website.matomo_tag_manager">
+                <script type="text/javascript">
+                    <t t-raw="website._matomo_tag_manager_script()"/>
+                </script>
+                <!-- End Matomo Tag Manager -->
+            </t>
+
+        </xpath>
+    </template>
+
+</odoo>

--- a/website_matomo_tag_manager/views/website.xml
+++ b/website_matomo_tag_manager/views/website.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_website_form" model="ir.ui.view">
+        <field name="model">website</field>
+        <field name="inherit_id" ref="website.view_website_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='other']" position="inside">
+                <group>
+                    <field name="matomo_tag_manager"/>
+                    <field name="matomo_host_name" attrs="{'invisible': [('matomo_tag_manager','=',False)], 'required': [('matomo_tag_manager','=',True)]}"/>
+                    <field name="matomo_container_ref" attrs="{'invisible': [('matomo_tag_manager','=',False)], 'required': [('matomo_tag_manager','=',True)]}"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/website_matomo_tag_manager/views/website_config_settings.xml
+++ b/website_matomo_tag_manager/views/website_config_settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_website_config_settings" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div id="google_analytics_setting" position="after">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="matomo_tag_manager_setting">
+                    <div class="o_setting_left_pane">
+                        <field name="matomo_tag_manager"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="matomo_tag_manager"/>
+                        <div class="text-muted">
+                            Track visits using Matomo Tag Manager
+                        </div>
+                        <div class="content-group" attrs="{'invisible': [('matomo_tag_manager', '=', False)]}">
+                            <div class="row mt16">
+                                <label class="col-md-3 o_light_label" for="matomo_host_name"/>
+                                <field name="matomo_host_name"  attrs="{'required': [('matomo_tag_manager','=',True)]}"/>
+                            </div>
+                        </div>
+                        <div attrs="{'invisible': [('matomo_tag_manager', '=', False)]}">
+                            <div class="row mt16">
+                                <label class="col-md-3 o_light_label" for="matomo_container_ref"/>
+                                <field name="matomo_container_ref" attrs="{'required': [('matomo_tag_manager','=',True)]}"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
his module introduces the Matomo Tag Manager JS script on all the website pages.
For all websites selected by the user settings/website (front-end) or website/configuration/websites. The JS script gets inserted in the head of each page as first script, as desired by Matomo for analysis.