### PR TITLE
[13.0][FIX] website_cookiefirst: resource loading

### DIFF
--- a/website_cookiefirst/views/portal_template.xml
+++ b/website_cookiefirst/views/portal_template.xml
@@ -9,19 +9,19 @@
                 <a href="/legal/cookies-policy">Cookies Policy</a>
             </span>
         </xpath>
-        <xpath expr="//script[last()]" position="after">
+    </template>
+    <template id="layout" inherit_id="website.layout">
+        <xpath expr="//script[@id='tracking_code']" position="attributes">
+            <attribute name="type">text/plain</attribute>
+            <attribute name="data-cookiefirst-category">performance</attribute>
+        </xpath>
+        <xpath expr="//script[@id='tracking_code']" position="after">
             <t t-if="website.cookiefirst_identifier">
                 <script
                     src="https://consent.cookiefirst.com/banner.js"
                     t-att-data-cookiefirst-key="website.cookiefirst_identifier"
                 />
             </t>
-        </xpath>
-    </template>
-    <template id="layout" inherit_id="website.layout">
-        <xpath expr="//script[@id='tracking_code']" position="attributes">
-            <attribute name="type">text/plain</attribute>
-            <attribute name="data-cookiefirst-category">performance</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Depending on the assets loading we could be loading incorrectly the
cookies banner and even block Google Analytics scripts with no chance to
unlock it. Moving the cookiefirst snippet to the bottom we prevent such
situations.

cc @Tecnativa TT37488 TT37473

ping @ioans73 