### PR TITLE
[FIX] website_form_builder: field html use field.text

### DIFF
--- a/website_form_builder/static/src/xml/snippets.xml
+++ b/website_form_builder/static/src/xml/snippets.xml
@@ -105,7 +105,7 @@
 
     <t t-name="website_form_builder.field.html">
         <!-- TODO Use a safe HTML widget instead -->
-        <t t-call="website_form_builder.text"/>
+        <t t-call="website_form_builder.field.text"/>
     </t>
 
     <t t-name="website_form_builder.field.integer">


### PR DESCRIPTION
The field HTML need `website_form_builder.field.text` instead of `website_form_builder.text` in t-call.
The bug show an error when choose HTML field.