### PR TITLE
[15.0][FIX] website_crm_privacy_policy: Fixed error calling a template that does not exist

### DIFF
--- a/website_crm_privacy_policy/templates/contactus.xml
+++ b/website_crm_privacy_policy/templates/contactus.xml
@@ -22,7 +22,11 @@
                         required="required"
                     />
                     <label class="form-check-label" for="privacy_policy">
-                        <t t-call="website_legal_page.acceptance_full" />
+                        <span class="acceptance_full">
+                            <a
+                                href="/legal"
+                            >I accept the legal terms, the privacy policy &amp; conditions of this website.</a>
+                        </span>
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
In the contact us form there was a call to the website_legal_page.acceptance_full template that no longer exists, it has been corrected so that it does not give error replicating that template directly.

cc @Tecnativa TT42194

@CarlosRoca13 @pedrobaeza please review :)
