### PR TITLE
[13.0][FIX] website_google_analytics_4 mime type

### DIFF
--- a/website_google_analytics_4/views/website_templates.xml
+++ b/website_google_analytics_4/views/website_templates.xml
@@ -8,17 +8,11 @@
         <xpath expr="//script[@id='tracking_code']" position="replace">
             <script
                 id="google_analytics_4_code"
-                type="text/plain"
-                data-cookiefirst-category="performance"
                 t-if="website and website.google_analytics_key and not editable"
                 async="1"
                 t-attf-src="https://www.googletagmanager.com/gtag/js?id={{ website.google_analytics_key }}"
             />
-            <script
-                type="text/plain"
-                data-cookiefirst-category="performance"
-                t-if="website and website.google_analytics_key and not editable"
-            >
+            <script t-if="website and website.google_analytics_key and not editable">
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){
                     dataLayer.push(arguments);


### PR DESCRIPTION
In some casesGoogle won't perform the tracking. Looks like the mainoffender was thee mimetype. The recommendation is to omit the attribute in the script element when is js code though:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type

cc @Tecnativa TT44128

please review @pedrobaeza @miguel-S73 
