### PR TITLE
[13.0][FIX] website_prevent_cls: ensure bin_size is False before retreving signature

### DIFF
--- a/website_prevent_cls/__init__.py
+++ b/website_prevent_cls/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import tests

--- a/website_prevent_cls/models/ir_qweb_fields.py
+++ b/website_prevent_cls/models/ir_qweb_fields.py
@@ -33,6 +33,7 @@ class Image(models.AbstractModel):
     @api.model
     def record_to_html(self, record, field_name, options):
         base64_signature = False
+        record = record.with_context(bin_size=False)
         if record and hasattr(record, field_name) and record[field_name]:
             base64_signature = record[field_name][:256]
         # don't process empty source or SVG

--- a/website_prevent_cls/tests/__init__.py
+++ b/website_prevent_cls/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_misc

--- a/website_prevent_cls/tests/test_misc.py
+++ b/website_prevent_cls/tests/test_misc.py
@@ -1,0 +1,20 @@
+from odoo.tests import SavepointCase
+
+ONE_PIXEL = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAJElEQVQI"
+    "mWP4/b/qPzbM8Pt/1X8GBgaEAJTNgFcHXqOQMV4dAMmObXXo1/BqAAAA"
+    "AElFTkSuQmCC"
+)
+
+
+class TestMisc(SavepointCase):
+    def test_bin_size(self):
+        record = self.env.ref("base.main_partner")
+        field_name = "image_1920"
+
+        record.write({field_name: ONE_PIXEL})
+        record.invalidate_cache()
+
+        self.env["ir.qweb.field.image"].record_to_html(
+            record.with_context(bin_size=True), field_name, {"tagName": "div"}
+        )


### PR DESCRIPTION
Before this PR this traceback could appear if bin_size is True.
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/odoo/tools/cache.py", line 88, in lookup
    r = d[key]
  File "/usr/local/lib/python3.6/site-packages/odoo/tools/func.py", line 69, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/odoo/tools/lru.py", line 44, in __getitem__
    a = self.d[obj].me
KeyError: ('ir.qweb.field.image', <function Image._get_image_size at 0x7f2ded65d1e0>, '83.24 Kb')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/mnt/extra-addons/OCA/website/website_prevent_cls/tools/image.py", line 23, in base64_to_image
    return Image.open(io.BytesIO(base64.b64decode(base64_source)))
  File "/usr/local/lib/python3.6/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Incorrect padding

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/mnt/extra-addons/OCA/website/website_prevent_cls/models/ir_qweb_fields.py", line 42, in record_to_html
    width, height = self._get_image_size(record, field_name, base64_signature)
  File "<decorator-gen-268>", line 2, in _get_image_size
  File "/usr/local/lib/python3.6/site-packages/odoo/tools/cache.py", line 93, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/mnt/extra-addons/OCA/website/website_prevent_cls/models/ir_qweb_fields.py", line 29, in _get_image_size
    image = base64_to_image(base64_source)
  File "/mnt/extra-addons/OCA/website/website_prevent_cls/tools/image.py", line 25, in base64_to_image
    raise UserError(_("This file could not be decoded as an image file."
odoo.exceptions.UserError: ('This file could not be decoded as an image file.Please try with a different file.', '')

```