### PR TITLE
[16.0][FIX] website_legal_page: footer xpath

### DIFF
--- a/website_legal_page/views/website_legal_main_page.xml
+++ b/website_legal_page/views/website_legal_main_page.xml
@@ -8,7 +8,7 @@
         customize_show="True"
     >
         <xpath
-            expr="//footer//div/span[hasclass('o_footer_copyright_name')]"
+            expr="//footer//span[hasclass('o_footer_copyright_name')]"
             position="after"
         >
             <span class="legal_page">-


### PR DESCRIPTION
In some cases, Odoo wraps original span inside another span for translation making view fail. This change allows it to be found eitherwise.

![image](https://github.com/OCA/website/assets/6009746/9ee60924-9d0b-48d7-a3d6-aaba2b6ec046)

Steps to reproduce:
1. Add a new website with one language
2. In this website, add another language
3. From main page of website, switch to the second language
4. Enter translate menu

![image](https://github.com/OCA/website/assets/6009746/8c667a42-4ed2-425f-8b89-82c7f4f0237b)

Reproduced on [runboat](http://oca-website-16-0-0115ca85d00b.runboat.odoo-community.org/), website *My Website - 1018*

