### PR TITLE
[15.0][IMP] website_form_require_legal: Set link to terms and conditions

### DIFF
--- a/website_form_require_legal/static/src/js/options.js
+++ b/website_form_require_legal/static/src/js/options.js
@@ -35,7 +35,7 @@ odoo.define("website_form_require_legal.form_editor", function (require) {
                 $(template).html(
                     qweb.render("website_form_require_legal.s_website_form_legal", {
                         labelWidth: labelWidth,
-                        termsURL: "terms",
+                        termsURL: "/terms",
                     })
                 );
                 const legal = template.content.firstElementChild;

--- a/website_form_require_legal/static/src/xml/website_form_editor.xml
+++ b/website_form_require_legal/static/src/xml/website_form_editor.xml
@@ -18,7 +18,9 @@
                             class="s_website_form_input form-check-input"
                         />
                         <span class="form-check-label">
-                            Agree to <a href="#">terms and conditions</a>
+                            Agree to <a
+                                t-attf-href="#{termsURL or '#'}"
+                            >terms and conditions</a>
                         </span>
                         <div class="invalid-feedback">
                             You must agree before submitting.


### PR DESCRIPTION
Improve the template by allowing to set the URL when rendering the qweb template by setting a value for the termsURL variable by context.

cc @Tecnativa TT40305

@pedrobaeza @chienandalu please review