### PR TITLE
[14.0] [FIX] website_require_login: hidden exception

### DIFF
--- a/website_require_login/models/ir_http.py
+++ b/website_require_login/models/ir_http.py
@@ -2,6 +2,8 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 from pathlib import Path
 
+from psycopg2 import OperationalError
+
 from odoo import models
 from odoo.http import request
 
@@ -12,13 +14,19 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _dispatch(cls):
         res = super(IrHttp, cls)._dispatch()
-
         # if not website request - skip
-
         website = request.env["website"].sudo().get_current_website()
         if not website:
             return res
-        if request.uid == website.user_id.id:
+
+        # if it can't access the user_id,
+        # it means that an exception has been
+        # raised and the cursor is currently closed
+        try:
+            user = website.user_id
+        except OperationalError:
+            return res
+        if request.uid == user.id:
             auth_paths = (
                 request.env["website.auth.url"]
                 .sudo()


### PR DESCRIPTION
Fixed an issue where if an exception has been raised, it would try to access a closed cursor, causing the disconnection and re-connection from the website, totally hiding the exception message.

Traceback (partial):
```
File "/opt/odoo/custom/src/odoo/odoo/service/wsgi_server.py", line 113, in application
  return application_unproxied(environ, start_response)
File "/opt/odoo/custom/src/odoo/odoo/service/wsgi_server.py", line 88, in application_unproxied
  result = odoo.http.root(environ, start_response)
File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1341, in __call__
  return self.dispatch(environ, start_response)
File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1307, in __call__
  return self.app(environ, start_wrapped)
File "/usr/local/lib/python3.8/site-packages/werkzeug/middleware/shared_data.py", line 220, in __call__
  return self.app(environ, start_response)
File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1530, in dispatch
  result = ir_http._dispatch()
File "/opt/odoo/custom/src/website/website_require_login/models/ir_http.py", line 21, in _dispatch
  if request.uid == website.user_id.id:
File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 2494, in __get__
  return super().__get__(records, owner)
File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1020, in __get__
  recs._fetch_field(self)
File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3085, in _fetch_field
  self._read(fnames)
File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3152, in _read
  cr.execute(query_str, params + [sub_ids])
File "<decorator-gen-5>", line 2, in execute
  
File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 101, in check
  return f(self, *args, **kwargs)
File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 301, in execute
  res = self._obj.execute(query, params)
psycopg2.errors.InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block
```

pre-commit is fixed in: https://github.com/OCA/website/pull/1037