### PR TITLE
[14.0][FIX] broken translate button website legal page

### DIFF
--- a/website_legal_page/views/website_legal_main_page.xml
+++ b/website_legal_page/views/website_legal_main_page.xml
@@ -8,7 +8,7 @@
         customize_show="True"
     >
         <xpath
-            expr="//footer//div/span[hasclass('o_footer_copyright_name')]"
+            expr="//footer//span[hasclass('o_footer_copyright_name','mr-2')]"
             position="after"
         >
             <span class="legal_page">-


### PR DESCRIPTION
## To Reproduce

* install alternative language
* enable alternative language on website
* access any page, select alternative language and click "TRANSLATE" button: you will get an error unless you disable option "Legal Page Link"

## After commit

This commit correct xpath reference so we don't need to disable the legal page link template in order to translate website pages.