### PR TITLE
[FIX] website_google_tag_manager: fix hidden menu behavior with tag manager

### DIFF
--- a/website_google_tag_manager/views/website_templates.xml
+++ b/website_google_tag_manager/views/website_templates.xml
@@ -2,7 +2,7 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <template id="layout" inherit_id="website.layout">
-        <xpath expr="//div[@id='wrapwrap']" position="before">
+        <xpath expr="//div[@id='wrapwrap']" position="after">
             <t t-if="website and website.google_tag_manager_key">
                 <!-- Google Tag Manager (noscript) -->
                 <noscript>


### PR DESCRIPTION
Adding script before the wrapwrap element affects style [1] and hide the nav bar behind of the main menu, so it is required adding it after the wrapwrap element, the same way as [2] does it.

Reference:

- [1] https://github.com/odoo/odoo/blob/32a07bf4/addons/website/static/src/scss/website.scss#L200
- [2] https://github.com/odoo/odoo/blob/32a07bf4/addons/website/views/website_templates.xml#L151

This is a forward-port from https://github.com/OCA/website/pull/1052