### PR TITLE
[16.0][FIX] website_whatsapp: messages shown should be translatable.

### DIFF
--- a/website_whatsapp/models/res_config_settings.py
+++ b/website_whatsapp/models/res_config_settings.py
@@ -24,7 +24,6 @@ class ResConfigSettings(models.TransientModel):
     whatsapp_text = fields.Char(
         related="website_id.whatsapp_text",
         readonly=False,
-        translate=True,
     )
     whatsapp_track_url = fields.Boolean(
         related="website_id.whatsapp_track_url",

--- a/website_whatsapp/models/res_config_settings.py
+++ b/website_whatsapp/models/res_config_settings.py
@@ -24,6 +24,7 @@ class ResConfigSettings(models.TransientModel):
     whatsapp_text = fields.Char(
         related="website_id.whatsapp_text",
         readonly=False,
+        translate=True,
     )
     whatsapp_track_url = fields.Boolean(
         related="website_id.whatsapp_track_url",

--- a/website_whatsapp/models/website.py
+++ b/website_whatsapp/models/website.py
@@ -1,7 +1,9 @@
 # Copyright 2022 Studio73 - Ioan Galan <ioan@studio73.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from urllib.parse import urlparse, urlunparse
+
+from odoo import _, fields, models
 
 
 class Website(models.Model):
@@ -11,9 +13,24 @@ class Website(models.Model):
     whatsapp_text = fields.Char(
         "Default text for Whatsapp",
         help="Default text to send as message",
+        translate=True,
     )
     whatsapp_track_url = fields.Boolean(
         "Track URL",
         help="Indicate in the user's message the URL of the page from which it "
         "was sent",
     )
+
+    def _get_track_url_message(self, httprequest_full_path):
+        sent_from = _("Sent from:")
+        base_url = self.domain or self.env["ir.config_parameter"].sudo().get_param(
+            "web.base.url"
+        )
+        url = f"{base_url} {httprequest_full_path}"
+        parsed_url = urlparse(url)
+        cleaned_url = urlunparse(parsed_url._replace(query=""))
+        if self.whatsapp_track_url:
+            whatsapp_track_url_text = (
+                f"{self.whatsapp_text} %0A%0A*{sent_from} {cleaned_url}*"
+            )
+        return whatsapp_track_url_text

--- a/website_whatsapp/static/src/scss/website.scss
+++ b/website_whatsapp/static/src/scss/website.scss
@@ -1,32 +1,31 @@
-#whatsapp_icon {
-    z-index: 9999;
+$whatsapp-green: #01e675;
+$icon-size: 56px;
+
+.whatsapp_icon {
+    z-index: 5;
     position: fixed;
-    bottom: 50px;
-    right: 30px;
-    background: #01e675;
-    width: 50px;
-    height: 50px;
-    text-decoration: none;
-    -webkit-border-radius: 35px;
-    -moz-border-radius: 35px;
-    border-radius: 35px;
-    -webkit-transition: all 0.3s linear;
-    -moz-transition: all 0.3s ease;
-    -ms-transition: all 0.3s ease;
-    -o-transition: all 0.3s ease;
-    transition: all 0.3s ease;
-    border: 3px solid white;
+    inset: auto 30px 110px auto; // Right 30px, bottom 90px
     display: flex;
     justify-content: center;
     align-items: center;
+    width: $icon-size;
+    height: $icon-size;
+    background: $whatsapp-green;
+    border-radius: 50%;
+    cursor: pointer;
+    white-space: nowrap;
+    text-decoration: none;
+    padding: 0;
+    margin: 0;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+    transition: all 0.3s ease;
+
     i {
         color: #fff;
         font-size: 30px;
     }
-    @media (max-width: 576px) {
-        & {
-            bottom: 90px;
-            right: 10px;
-        }
+
+    &:hover {
+        filter: brightness(90%);
     }
 }

--- a/website_whatsapp/templates/website.xml
+++ b/website_whatsapp/templates/website.xml
@@ -11,7 +11,7 @@
             <t
                 t-if="website.whatsapp_track_url"
                 t-set="extra_info"
-                t-value="'{} %0A%0A*Sent from: {}{}*'.format(extra_info, request.website and request.website.domain or request.env['ir.config_parameter'].sudo().get_param('web.base.url'), request.httprequest.full_path)"
+                t-value="website._get_track_url_message(request.httprequest.full_path)"
             /><!-- %0A newline -->
             <a
                 t-if="website.whatsapp_number"

--- a/website_whatsapp/templates/website.xml
+++ b/website_whatsapp/templates/website.xml
@@ -13,15 +13,16 @@
                 t-set="extra_info"
                 t-value="website._get_track_url_message(request.httprequest.full_path)"
             /><!-- %0A newline -->
-            <a
-                t-if="website.whatsapp_number"
-                target="_blank"
-                t-attf-href="https://api.whatsapp.com/send?phone={{website.whatsapp_number}}&amp;text={{extra_info}}"
-                id="whatsapp_icon"
-                title="WhatsApp Floating Icon"
-            >
+            <div t-if="website.whatsapp_number" class="whatsapp_icon">
+                <a
+                    target="_blank"
+                    t-attf-href="https://api.whatsapp.com/send?phone={{website.whatsapp_number}}&amp;text={{extra_info}}"
+                    title="WhatsApp Floating Icon"
+                >
                 <i class="fa fa-whatsapp" />
             </a>
+            </div>
+
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
When a user starts the chat a message is proposed. This message should be translatable, so that it will appear in the language used by the user in the website.
