### PR TITLE
[16.0][IMP] website_whatsapp: restrict the visibility of the whatsapp button by country

### DIFF
--- a/website_whatsapp/models/res_config_settings.py
+++ b/website_whatsapp/models/res_config_settings.py
@@ -34,3 +34,11 @@ class ResConfigSettings(models.TransientModel):
         compute="_compute_whatsapp_enabled",
         inverse="_inverse_whatsapp_enabled",
     )
+    whatsapp_included_country_ids = fields.Many2many(
+        related="website_id.whatsapp_included_country_ids",
+        readonly=False,
+    )
+    whatsapp_excluded_country_ids = fields.Many2many(
+        related="website_id.whatsapp_excluded_country_ids",
+        readonly=False,
+    )

--- a/website_whatsapp/models/website.py
+++ b/website_whatsapp/models/website.py
@@ -20,6 +20,19 @@ class Website(models.Model):
         help="Indicate in the user's message the URL of the page from which it "
         "was sent",
     )
+    whatsapp_included_country_ids = fields.Many2many(
+        string="Show Whatsapp only in Countries",
+        comodel_name="res.country",
+        relation="website_whatsapp_included_countries_rel",
+        help="When set, the whatsapp icon will only appear to the selected countries.",
+    )
+    whatsapp_excluded_country_ids = fields.Many2many(
+        string="Do not show Whatsapp in Countries",
+        comodel_name="res.country",
+        relation="website_whatsapp_excluded_countries_rel",
+        help="When set, the whatsapp icon will only appear when the "
+        "country of the user is not within this list.",
+    )
 
     def _get_track_url_message(self, httprequest_full_path):
         sent_from = _("Sent from:")
@@ -34,3 +47,29 @@ class Website(models.Model):
                 f"{self.whatsapp_text} %0A%0A*{sent_from} {cleaned_url}*"
             )
         return whatsapp_track_url_text
+
+    def _check_display_whatsapp_icon(self, request):
+        self.ensure_one()
+        if not self.whatsapp_number:
+            return False
+        geoip_country_code = request.geoip.get("country_code")
+        country = request.env["res.country"].sudo()
+        if geoip_country_code:
+            country = (
+                request.env["res.country"]
+                .sudo()
+                .search([("code", "=", geoip_country_code)], limit=1)
+            )
+        if (
+            country
+            and self.whatsapp_included_country_ids
+            and country not in self.whatsapp_included_country_ids
+        ):
+            return False
+        if (
+            country
+            and self.whatsapp_excluded_country_ids
+            and country in self.whatsapp_excluded_country_ids
+        ):
+            return False
+        return True

--- a/website_whatsapp/templates/website.xml
+++ b/website_whatsapp/templates/website.xml
@@ -13,7 +13,10 @@
                 t-set="extra_info"
                 t-value="website._get_track_url_message(request.httprequest.full_path)"
             /><!-- %0A newline -->
-            <div t-if="website.whatsapp_number" class="whatsapp_icon">
+            <div
+                t-if="website._check_display_whatsapp_icon(request)"
+                class="whatsapp_icon"
+            >
                 <a
                     target="_blank"
                     t-attf-href="https://api.whatsapp.com/send?phone={{website.whatsapp_number}}&amp;text={{extra_info}}"

--- a/website_whatsapp/views/res_config_settings.xml
+++ b/website_whatsapp/views/res_config_settings.xml
@@ -50,6 +50,28 @@
                                 />
                                 <field name="whatsapp_track_url" class="oe_inline" />
                             </div>
+                            <div class="row">
+                                <label
+                                    class="col-lg-3 o_light_label"
+                                    for="whatsapp_included_country_ids"
+                                />
+                                <field
+                                    name="whatsapp_included_country_ids"
+                                    class="oe_inline"
+                                    widget="many2many_tags"
+                                />
+                            </div>
+                            <div class="row">
+                                <label
+                                    class="col-lg-3 o_light_label"
+                                    for="whatsapp_excluded_country_ids"
+                                />
+                                <field
+                                    name="whatsapp_excluded_country_ids"
+                                    class="oe_inline"
+                                    widget="many2many_tags"
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Introduces a whitelisted countries and blacklisted countries, so that the icon can optionally appear only in selected countries.

![image](https://github.com/user-attachments/assets/3f13724b-6bb1-4d03-9796-876918541995)
