### PR TITLE
[16.0][FIX] website_google_tag_manager: link

### DIFF
--- a/website_google_tag_manager/i18n/es.po
+++ b/website_google_tag_manager/i18n/es.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * website_google_tag_manager
+# 	* website_google_tag_manager
 #
 # Translators:
 # Pedro M. Baeza <pedro.baeza@gmail.com>, 2016
 # OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 04:16+0000\n"
 "PO-Revision-Date: 2023-09-03 13:39+0000\n"
@@ -19,6 +19,15 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.17\n"
+
+#. module: website_google_tag_manager
+#: model_terms:ir.ui.view,arch_db:website_google_tag_manager.view_website_config_settings
+msgid ""
+"<i class=\"fa fa-arrow-right\"/>\n"
+"                                How to get my GTM container ID"
+msgstr ""
+"<i class=\"fa fa-arrow-right\"/>\n"
+"                                Cómo obtener mi ID de contenedor GTM"
 
 #. module: website_google_tag_manager
 #: model_terms:ir.ui.view,arch_db:website_google_tag_manager.view_website_config_settings
@@ -43,17 +52,12 @@ msgstr "ID de Contenedor"
 #. module: website_google_tag_manager
 #: model_terms:ir.ui.view,arch_db:website_google_tag_manager.view_website_config_settings
 msgid "GTM-XXXXX"
-msgstr "GTM-XXXXX"
+msgstr ""
 
 #. module: website_google_tag_manager
 #: model_terms:ir.ui.view,arch_db:website_google_tag_manager.view_website_config_settings
 msgid "Google Tag Manager"
 msgstr "Gestor de etiquetas de Google"
-
-#. module: website_google_tag_manager
-#: model_terms:ir.ui.view,arch_db:website_google_tag_manager.view_website_config_settings
-msgid "How to get my GTM container ID"
-msgstr "Cómo obtener mi ID de contenedor GTM"
 
 #. module: website_google_tag_manager
 #: model_terms:ir.ui.view,arch_db:website_google_tag_manager.view_website_config_settings

--- a/website_google_tag_manager/views/res_config_settings_view.xml
+++ b/website_google_tag_manager/views/res_config_settings_view.xml
@@ -41,9 +41,10 @@
                         <div>
                             <a
                                 href="https://support.google.com/tagmanager/answer/6103696#install?hl=en"
-                                class="oe_link fa fa-arrow-right"
+                                class="oe_link"
                                 target="_blank"
                             >
+                                <i class="fa fa-arrow-right" />
                                 How to get my GTM container ID
                             </a>
                         </div>


### PR DESCRIPTION
Font awesome classes were not right placed, causing link text to be rendered wrong

Before:

![image](https://github.com/user-attachments/assets/87ee5fe6-cc19-4908-b9c2-aa2c84a7e89f)

![image](https://github.com/user-attachments/assets/10b0a50a-870a-4c1f-8ae8-759145eac815)


After:

![image](https://github.com/user-attachments/assets/d69051e3-9e87-4e42-b2f3-9e6fd49e8f36)


FL-556-5806