### PR TITLE
[FP][IMP] website_cookiefirst: Replace deprecated Cookiefirst functionality

### DIFF
--- a/website_cookiefirst/README.rst
+++ b/website_cookiefirst/README.rst
@@ -44,9 +44,10 @@ To configure this module, you need to:
 
 1. Go to **Website > Configuration > Settings**
 2. Search 'Cookiefirst' option.
-3. Fill in your 'Cookiefirst ID' (e.g.
-   '00000000-0000-0000-0000-000000000000').
-4. Click on "Save" button.
+3. Enable Use Cookiefirst checkbox
+4. Enter your Cookiefirst **API Key** into **Cookiefirst ID** field
+   (e.g. '00000000-0000-0000-0000-000000000000').
+5. Click on "Save" button.
 
 ⚠️ **Please note: if another cookie consent solution is installed (e.g.
 Cookiebot), the execution of the Cookiefirst script will be prevented.
@@ -74,13 +75,14 @@ Authors
 Contributors
 ------------
 
-- `Studio73 <https://www.studio73.es>`__:
+-  `Studio73 <https://www.studio73.es>`__:
 
-  - Ioan Galan <ioan@studio73.es>
+   -  Ioan Galan <ioan@studio73.es>
 
-- `NICO SOLUTIONS - ENGINEERING & IT <https://www.nico-solutions.de>`__:
+-  `NICO SOLUTIONS - ENGINEERING &
+   IT <https://www.nico-solutions.de>`__:
 
-  - Nils Coenen nils.coenen@nico-solutions.de
+   -  Nils Coenen nils.coenen@nico-solutions.de
 
 Maintainers
 -----------

--- a/website_cookiefirst/readme/CONFIGURE.md
+++ b/website_cookiefirst/readme/CONFIGURE.md
@@ -2,9 +2,10 @@ To configure this module, you need to:
 
 1.  Go to **Website \> Configuration \> Settings**
 2.  Search 'Cookiefirst' option.
-3.  Fill in your 'Cookiefirst ID' (e.g.
+3.  Enable Use Cookiefirst checkbox
+4.  Enter your Cookiefirst **API Key** into **Cookiefirst ID** field (e.g.
     '00000000-0000-0000-0000-000000000000').
-4.  Click on "Save" button.
+5.  Click on "Save" button.
 
 ⚠️ **Please note: if another cookie consent solution is
 installed (e.g. Cookiebot), the execution of the Cookiefirst

--- a/website_cookiefirst/static/description/index.html
+++ b/website_cookiefirst/static/description/index.html
@@ -392,8 +392,9 @@ website domain in Cookiefirst’s portal.</p>
 <ol class="arabic simple">
 <li>Go to <strong>Website &gt; Configuration &gt; Settings</strong></li>
 <li>Search ‘Cookiefirst’ option.</li>
-<li>Fill in your ‘Cookiefirst ID’ (e.g.
-‘00000000-0000-0000-0000-000000000000’).</li>
+<li>Enable Use Cookiefirst checkbox</li>
+<li>Enter your Cookiefirst <strong>API Key</strong> into <strong>Cookiefirst ID</strong> field
+(e.g. ‘00000000-0000-0000-0000-000000000000’).</li>
 <li>Click on “Save” button.</li>
 </ol>
 <p>⚠️ <strong>Please note: if another cookie consent solution is installed (e.g.
@@ -424,7 +425,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Ioan Galan &lt;<a class="reference external" href="mailto:ioan&#64;studio73.es">ioan&#64;studio73.es</a>&gt;</li>
 </ul>
 </li>
-<li><a class="reference external" href="https://www.nico-solutions.de">NICO SOLUTIONS - ENGINEERING &amp; IT</a>:<ul>
+<li><a class="reference external" href="https://www.nico-solutions.de">NICO SOLUTIONS - ENGINEERING &amp;
+IT</a>:<ul>
 <li>Nils Coenen <a class="reference external" href="mailto:nils.coenen&#64;nico-solutions.de">nils.coenen&#64;nico-solutions.de</a></li>
 </ul>
 </li>

--- a/website_cookiefirst/views/website_template.xml
+++ b/website_cookiefirst/views/website_template.xml
@@ -17,10 +17,9 @@
             <attribute name="data-cookiefirst-category">performance</attribute>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="after">
-            <t t-if="website.cookiefirst_identifier">
+            <t t-if="website.cookiefirst_identifier and website.domain">
                 <script
-                    src="https://consent.cookiefirst.com/banner.js"
-                    t-att-data-cookiefirst-key="website.cookiefirst_identifier"
+                    t-attf-src="https://consent.cookiefirst.com/sites/{{ (website.domain or '').replace('http://', '').replace('https://', '').replace('www.', '') }}-{{ website.cookiefirst_identifier }}/consent.js"
                 />
             </t>
         </xpath>


### PR DESCRIPTION
- replace banner.js with new consent.js script using domain and identifier
- forward ported from V17 PR (https://github.com/OCA/website/pull/1110)