### PR TITLE
[BP][IMP] website_cookiefirst: Replace deprecated Cookiefirst functionality

### DIFF
--- a/website_cookiefirst/README.rst
+++ b/website_cookiefirst/README.rst
@@ -42,10 +42,12 @@ Configuration
 
 To configure this module, you need to:
 
-#. Go to **Website > Configuration > Settings**
-#. Search 'Cookiefirst' option.
-#. Fill in your 'Cookiefirst ID' (e.g. '00000000-0000-0000-0000-000000000000').
-#. Click on "Save" button.
+1.  Go to **Website \> Configuration \> Settings**
+2.  Search 'Cookiefirst' option.
+3.  Enable Use Cookiefirst checkbox
+4.  Enter your Cookiefirst **API Key** into **Cookiefirst ID** field (e.g.
+    '00000000-0000-0000-0000-000000000000').
+5.  Click on "Save" button.
 
 Bug Tracker
 ===========

--- a/website_cookiefirst/readme/CONFIGURE.rst
+++ b/website_cookiefirst/readme/CONFIGURE.rst
@@ -1,6 +1,8 @@
 To configure this module, you need to:
 
-#. Go to **Website > Configuration > Settings**
-#. Search 'Cookiefirst' option.
-#. Fill in your 'Cookiefirst ID' (e.g. '00000000-0000-0000-0000-000000000000').
-#. Click on "Save" button.
+1.  Go to **Website \> Configuration \> Settings**
+2.  Search 'Cookiefirst' option.
+3.  Enable Use Cookiefirst checkbox
+4.  Enter your Cookiefirst **API Key** into **Cookiefirst ID** field (e.g.
+    '00000000-0000-0000-0000-000000000000').
+5.  Click on "Save" button.

--- a/website_cookiefirst/static/description/index.html
+++ b/website_cookiefirst/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -392,7 +392,9 @@ domain in Cookiefirst’s portal.</p>
 <ol class="arabic simple">
 <li>Go to <strong>Website &gt; Configuration &gt; Settings</strong></li>
 <li>Search ‘Cookiefirst’ option.</li>
-<li>Fill in your ‘Cookiefirst ID’ (e.g. ‘00000000-0000-0000-0000-000000000000’).</li>
+<li>Enable Use Cookiefirst checkbox</li>
+<li>Enter your Cookiefirst <strong>API Key</strong> into <strong>Cookiefirst ID</strong> field (e.g.
+‘00000000-0000-0000-0000-000000000000’).</li>
 <li>Click on “Save” button.</li>
 </ol>
 </div>
@@ -428,7 +430,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/website_cookiefirst/views/website_template.xml
+++ b/website_cookiefirst/views/website_template.xml
@@ -17,10 +17,9 @@
             <attribute name="data-cookiefirst-category">performance</attribute>
         </xpath>
         <xpath expr="//script[last()]" position="after">
-            <t t-if="website.cookiefirst_identifier">
+            <t t-if="website.cookiefirst_identifier and website.domain">
                 <script
-                    src="https://consent.cookiefirst.com/banner.js"
-                    t-att-data-cookiefirst-key="website.cookiefirst_identifier"
+                    t-attf-src="https://consent.cookiefirst.com/sites/{{ (website.domain or '').replace('http://', '').replace('https://', '').replace('www.', '') }}-{{ website.cookiefirst_identifier }}/consent.js"
                 />
             </t>
         </xpath>


### PR DESCRIPTION
- replace banner.js with new consent.js script using domain and identifier
- back ported from V17 PR (https://github.com/OCA/website/pull/1110)