### PR TITLE
[17.0][FIX] website_cookiefirst: remove www. prefix from domain in cookiefirst script URL

### DIFF
--- a/website_cookiefirst/views/website_template.xml
+++ b/website_cookiefirst/views/website_template.xml
@@ -19,7 +19,7 @@
         <xpath expr="//script[last()]" position="after">
             <t t-if="website.cookiefirst_identifier and website.domain">
                 <script
-                    t-attf-src="https://consent.cookiefirst.com/sites/{{ (website.domain or '').replace('http://', '').replace('https://', '') }}-{{ website.cookiefirst_identifier }}/consent.js"
+                    t-attf-src="https://consent.cookiefirst.com/sites/{{ (website.domain or '').replace('http://', '').replace('https://', '').replace('www.', '') }}-{{ website.cookiefirst_identifier }}/consent.js"
                 />
             </t>
         </xpath>


### PR DESCRIPTION
fix for domains with "www." subdomain as discussed here...https://github.com/OCA/website/pull/1110