### PR TITLE
[FIX] website_require_login: Disconnect notification on SQL error

### DIFF
--- a/website_require_login/README.rst
+++ b/website_require_login/README.rst
@@ -65,6 +65,9 @@ Contributors
 ~~~~~~~~~~~~
 
 * Ooops404 <https://ooops404.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/website_require_login/models/ir_http.py
+++ b/website_require_login/models/ir_http.py
@@ -1,8 +1,9 @@
 # Copyright 2020 Advitus MB
+# Copyright 2025 Simone Rubino - PyTech
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 from pathlib import Path
 
-from psycopg2 import OperationalError
+from psycopg2 import InternalError
 
 from odoo import models
 from odoo.http import request
@@ -24,7 +25,9 @@ class IrHttp(models.AbstractModel):
         # raised and the cursor is currently closed
         try:
             user = website.user_id
-        except OperationalError:
+        except InternalError:
+            # The real exception is InFailedSqlTransaction
+            # it will be available in psycopg2>=2.8.*
             return res
         if request.uid == user.id:
             auth_paths = (

--- a/website_require_login/readme/CONTRIBUTORS.rst
+++ b/website_require_login/readme/CONTRIBUTORS.rst
@@ -1,1 +1,4 @@
 * Ooops404 <https://ooops404.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/website_require_login/static/description/index.html
+++ b/website_require_login/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -409,12 +410,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li>Ooops404 &lt;<a class="reference external" href="https://ooops404.com">https://ooops404.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/website_require_login/tests/test_ir_http.py
+++ b/website_require_login/tests/test_ir_http.py
@@ -1,4 +1,10 @@
+# Copyright 2025 Simone Rubino - PyTech
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+
+import json
+
 from odoo.tests import HttpCase
+from odoo.tools import mute_logger
 
 
 class TestIrHttp(HttpCase):
@@ -35,3 +41,32 @@ class TestIrHttp(HttpCase):
             200,
             "Expected the response status code to be 200 which means no redirection",
         )
+
+    def test_dispatch_failed_transaction(self):
+        """If a transaction is failed, the exception is handled as usual."""
+        cron = self.env["ir.cron"].create(
+            {
+                "name": "Test failed transaction",
+                "code": "env.cr.execute('SELECT not_a_field FROM res_users')",
+                "model_id": self.env.ref("base.model_res_partner").id,
+            }
+        )
+        self.authenticate(user="admin", password="admin")
+        with mute_logger("odoo.sql_db", "odoo.http"):
+            response = self.url_open(
+                "/web/dataset/call_button",
+                headers={
+                    "Content-Type": "application/json",
+                },
+                data=json.dumps(
+                    {
+                        "params": {
+                            "model": cron._name,
+                            "method": "method_direct_trigger",
+                            "args": [cron.ids],
+                            "kwargs": {},
+                        },
+                    }
+                ),
+            )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Supersede https://github.com/OCA/website/pull/1147 to resolve https://github.com/OCA/website/pull/1147#pullrequestreview-3510971386.

How to reproduce the issue:

1. Create a CRON with code "env.cr.execute('SELECT not_a_field FROM res_users')"
2. Manually Execute the CRON

Expected behavior:
The Exception is shown in the UI

Actual behavior:
The "Disconnected" notification is briefly shown, and right after a "Connected" notification is shown