### PR TITLE
[FIX] website_require_login: Only redirect website requests

### DIFF
--- a/website_require_login/models/ir_http.py
+++ b/website_require_login/models/ir_http.py
@@ -8,6 +8,8 @@ from psycopg2 import InternalError
 from odoo import models
 from odoo.http import request
 
+from odoo.addons.website.models import ir_http
+
 
 class IrHttp(models.AbstractModel):
     _inherit = "ir.http"
@@ -16,6 +18,9 @@ class IrHttp(models.AbstractModel):
     def _dispatch(cls):
         res = super(IrHttp, cls)._dispatch()
         # if not website request - skip
+        if not ir_http.get_request_website():
+            return res
+
         website = request.env["website"].sudo().get_current_website()
         if not website:
             return res

--- a/website_require_login/tests/test_ir_http.py
+++ b/website_require_login/tests/test_ir_http.py
@@ -6,6 +6,8 @@ import json
 from odoo.tests import HttpCase
 from odoo.tools import mute_logger
 
+from odoo.addons.bus.controllers.main import BusController
+
 
 class TestIrHttp(HttpCase):
     def setUp(self):
@@ -69,4 +71,38 @@ class TestIrHttp(HttpCase):
                     }
                 ),
             )
+        self.assertEqual(response.status_code, 200)
+
+    def test_dispatch_no_website(self):
+        """If the request is not `website`, do not interfere."""
+        # Arrange
+        path = "/longpolling/poll"
+        routing = BusController().poll.routing
+        self.auth_url = self.env["website.auth.url"].create(
+            {
+                "website_id": self.website.id,
+                "path": path,
+            }
+        )
+        # pre-condition
+        self.assertFalse(routing.get("website"))
+        self.assertIn(path, routing.get("routes", dict()))
+
+        # Act
+        response = self.url_open(
+            path,
+            headers={
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(
+                {
+                    "params": {
+                        "channels": ["Test channel"],
+                        "last": 0,
+                    },
+                }
+            ),
+        )
+
+        # Assert
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Without this change, longpolling requests always fail with error:
> psycopg2.OperationalError: Unable to use a closed cursor.

<details><summary>Stack trace</summary>
<pre>
 2026-01-21 15:41:59,208 1 INFO db werkzeug: 172.19.0.7 - - [21/Jan/2026 15:41:59] "POST /longpolling/poll HTTP/1.1" 500 - 37 0.157 1.745
 Traceback (most recent call last):
   File "/opt/odoo/custom/src/odoo/odoo/api.py", line 799, in get
     return field_cache[record._ids[0]]
 KeyError: 1
 
 During handling of the above exception, another exception occurred:
 
 Traceback (most recent call last):
   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 993, in __get__
     value = env.cache.get(record, self)
   File "/opt/odoo/custom/src/odoo/odoo/api.py", line 802, in get
     raise CacheMiss(record, field)
 odoo.exceptions.CacheMiss: 'website(1,).user_id'
 
 During handling of the above exception, another exception occurred:
 
 Traceback (most recent call last):
   File "/opt/odoo/custom/src/odoo/odoo/service/wsgi_server.py", line 113, in application
     return application_unproxied(environ, start_response)
   File "/opt/odoo/custom/src/odoo/odoo/service/wsgi_server.py", line 88, in application_unproxied
     result = odoo.http.root(environ, start_response)
   File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1298, in __call__
     return self.dispatch(environ, start_response)
   File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1264, in __call__
     return self.app(environ, start_wrapped)
   File "/usr/local/lib/python3.8/site-packages/werkzeug/middleware/shared_data.py", line 220, in __call__
     return self.app(environ, start_response)
   File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1489, in dispatch
     result = ir_http._dispatch()
   File "/opt/odoo/custom/src/odoo/addons/website_sale/models/ir_http.py", line 15, in _dispatch
     return super(IrHttp, cls)._dispatch()
   File "/opt/odoo/custom/src/website/website_require_login/models/ir_http.py", line 29, in _dispatch
     user = website.user_id
   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 2493, in __get__
     return super().__get__(records, owner)
   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1019, in __get__
     recs._fetch_field(self)
   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3078, in _fetch_field
     self._read(fnames)
   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3145, in _read
     cr.execute(query_str, params + [sub_ids])
   File "<decorator-gen-5>", line 2, in execute
     
   File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 100, in check
     raise psycopg2.OperationalError('Unable to use a closed cursor.')
 psycopg2.OperationalError: Unable to use a closed cursor.
</pre>
</details> 

This module was also interfering with bus messages (like the ones from `web_notify`) and prevented them from being shown.

The called function `get_request_website` (https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/addons/website/models/ir_http.py#L43) exists with the exact purpose to identify when a request is coming from the website or not, from its docstring:
>  This method can typically be used to check if we are in the frontend.