### PR TITLE
[18.0][IMP] website_form_require_legal: use readable value for legal checkbox

### DIFF
--- a/website_form_require_legal/static/src/xml/website_form_editor.xml
+++ b/website_form_require_legal/static/src/xml/website_form_editor.xml
@@ -16,6 +16,8 @@
                             id="website_form_terms_and_conditions_input"
                             type="checkbox"
                             required="1"
+                            name="Accept_terms"
+                            value="accepted"
                             class="s_website_form_input form-check-input"
                         />
                         <span class="form-check-label">


### PR DESCRIPTION
Currently, the legal acceptance checkbox is submitted using the browser default value (on). When the form stores the value as an additional field, this results in a non-descriptive entry in the generated ticket or email.

Currently, the legal acceptance checkbox does not define a proper name attribute and relies on the browser default checkbox value (on). As a result, when the form data is stored by website_form, it generates a non-descriptive entry such as:

Before:

<img width="168" height="104" alt="image" src="https://github.com/user-attachments/assets/b6a9c838-6966-4a1f-baac-c04a35ae8449" />

unknown_field_1: on

After:

<img width="168" height="104" alt="image" src="https://github.com/user-attachments/assets/9c9acba5-5c73-4986-9ffa-66c54055f828" />

This change adds an explicit field name and a more readable checkbox value to improve the clarity of data generated by website_form.

@Tecnativa TT62453

@christian-ramos-tecnativa @carlos-lopez-tecnativa please review