### PR TITLE
[18.0][FIX] website_forum_subscription: avoid nested links in forum cards

### DIFF
--- a/website_forum_subscription/templates/website_forum_templates.xml
+++ b/website_forum_subscription/templates/website_forum_templates.xml
@@ -14,9 +14,11 @@
                 t-value="request.env.user.has_group('base.group_public')"
             />
             <div t-if="user_public">
-                <a class="btn btn-link" href="/web/login">
-                    <i class="fa fa-bell" /> Subscribe to forum notifications
-                </a>
+                <object>
+                    <a class="btn btn-link" href="/web/login">
+                        <i class="fa fa-bell" /> Subscribe to forum notifications
+                    </a>
+                </object>
             </div>
             <div
                 t-if="icons_design and not user_public"


### PR DESCRIPTION
Wrap the public subscription link in an <object> tag to avoid rendering an anchor inside the forum card anchor, which breaks the page layout for public users.
Like Odoo https://github.com/odoo/odoo/blob/e6a402933822adcd85f771159ab4abf58bda5d24/addons/website_forum/views/forum_forum_templates_forum_all.xml#L56-L61

Before:

<img width="1249" height="926" alt="image" src="https://github.com/user-attachments/assets/1934e26b-0833-466d-89fe-f94c4cab0d12" />


After:

<img width="1249" height="926" alt="image" src="https://github.com/user-attachments/assets/871e816f-1b8e-4b75-8c96-e58d780fab8a" />


@Tecnativa 

@pedrobaeza @victoralmau please review