### PR TITLE
[17.0][FIX] website_forum_subscription: avoid nested links in forum cards

### DIFF
--- a/website_forum_subscription/templates/website_forum_templates.xml
+++ b/website_forum_subscription/templates/website_forum_templates.xml
@@ -14,9 +14,11 @@
                 t-value="request.env.user.has_group('base.group_public')"
             />
             <div t-if="user_public">
-                <a class="btn btn-link" href="/web/login">
-                    <i class="fa fa-bell" /> Subscribe to forum notifications
-                </a>
+                <object>
+                    <a class="btn btn-link" href="/web/login">
+                        <i class="fa fa-bell" /> Subscribe to forum notifications
+                    </a>
+                </object>
             </div>
             <div
                 t-if="icons_design and not user_public"


### PR DESCRIPTION
bp https://github.com/OCA/website/pull/1193

Wrap the public subscription link in an <object> tag to avoid rendering an anchor inside the forum card anchor, which breaks the page layout for public users.

@Tecnativa

@pedrobaeza @victoralmau please review