### PR TITLE
[18.0][FIX] website_forum_subscription: prevent visible follow email field

### DIFF
--- a/website_forum_subscription/templates/website_forum_templates.xml
+++ b/website_forum_subscription/templates/website_forum_templates.xml
@@ -13,6 +13,7 @@
                 t-set="user_public"
                 t-value="request.env.user.has_group('base.group_public')"
             />
+            <input type="hidden" class="js_follow_email" disabled="disabled" />
             <div t-if="user_public">
                 <object>
                     <a class="btn btn-link" href="/web/login">


### PR DESCRIPTION
Add a hidden `js_follow_email` field so `website_mail` does not automatically inject a visible email input in forum subscriptions.

Before
<img width="749" height="609" alt="image" src="https://github.com/user-attachments/assets/308cb685-e8ac-425c-b4dd-a52619097fea" />

After
<img width="727" height="554" alt="image" src="https://github.com/user-attachments/assets/c71fbd1d-083e-453c-b537-dbb45d962d61" />

@Tecnativa TT62994

@pedrobaeza @victoralmau please review

