### PR TITLE
[18.0][IMP] website_forum_subscription: bypass captcha on forum subscriptions

### DIFF
--- a/website_forum_subscription/templates/website_forum_templates.xml
+++ b/website_forum_subscription/templates/website_forum_templates.xml
@@ -3,7 +3,7 @@
     <!-- Uses the gears of website_mail for the UI enhancements -->
     <template id="follow">
         <div
-            t-attf-class="input-group js_follow #{div_class}"
+            t-attf-class="input-group js_follow o_website_mail_follow_no_recaptcha #{div_class}"
             t-att-data-id="object.id"
             t-att-data-object="object._name"
             t-att-data-follow="object.id and object.message_is_follower and 'on' or 'off'"


### PR DESCRIPTION
Pending from:
- [ ] https://github.com/odoo/odoo/pull/269697

Forum subscriptions rely on the `website_mail` follow widget and are expected to behave as an immediate subscribe/unsubscribe action.

When `website_cf_turnstile` is enabled, the captcha validation flow may introduce a noticeable delay before the subscription is processed, resulting in a degraded user experience.

Mark forum subscription widgets with
`o_website_mail_follow_no_recaptcha` to use the opt-out mechanism provided by `website_mail` and bypass captcha validation for these interactions.

TT62994