### PR TITLE
[18.0][FIX] website_altcha: Add sitemap value for `/altcha` route

### DIFF
--- a/website_altcha/controllers/altcha.py
+++ b/website_altcha/controllers/altcha.py
@@ -9,7 +9,7 @@ from odoo.http import request
 
 
 class AltchaController(http.Controller):
-    @http.route("/altcha", type="http", auth="public", website=True)
+    @http.route("/altcha", type="http", auth="public", website=True, sitemap=False)
     def generate_altcha_challenge(self):
         timeout = int(request.website.sudo().altcha_timeout or 5)
         cost = int(request.website.sudo().altcha_cost or 1_000)


### PR DESCRIPTION
Small change to remove this warning:

```
2026-07-03 11:09:30,020 351 WARNING odoo odoo.addons.website.models.website: No Sitemap value provided for controller <function AltchaController.generate_altcha_challenge at 0x7f7a28b05870> (/altcha) 
```
