### PR TITLE
[18.0][FIX] website_form_require_legal: avoid overriding payment terms widget

### DIFF
--- a/website_form_require_legal/static/src/js/terms_and_conditions.esm.js
+++ b/website_form_require_legal/static/src/js/terms_and_conditions.esm.js
@@ -3,26 +3,27 @@
 import {Component} from "@odoo/owl";
 import publicWidget from "@web/legacy/js/public/public_widget";
 
-publicWidget.registry.TermsAndConditionsCheckbox = publicWidget.Widget.extend({
-    selector: 'div[name="website_form_terms_and_conditions"]',
-    events: {
-        "change #website_form_terms_and_conditions_input": "_onClickCheckbox",
-    },
+publicWidget.registry.WebsiteFormTermsAndConditionsCheckbox =
+    publicWidget.Widget.extend({
+        selector: 'div[name="website_form_terms_and_conditions"]',
+        events: {
+            "change #website_form_terms_and_conditions_input": "_onClickCheckbox",
+        },
 
-    async start() {
-        this.checkbox = this.el.querySelector(
-            "#website_form_terms_and_conditions_input"
-        );
-        Component.env.bus.trigger("enableSubmitButton");
-        return this._super(...arguments);
-    },
-    _onClickCheckbox() {
-        if (this.checkbox.checked) {
+        async start() {
+            this.checkbox = this.el.querySelector(
+                "#website_form_terms_and_conditions_input"
+            );
             Component.env.bus.trigger("enableSubmitButton");
-        } else {
-            Component.env.bus.trigger("disableSubmitButton");
-        }
-    },
-});
+            return this._super(...arguments);
+        },
+        _onClickCheckbox() {
+            if (this.checkbox.checked) {
+                Component.env.bus.trigger("enableSubmitButton");
+            } else {
+                Component.env.bus.trigger("disableSubmitButton");
+            }
+        },
+    });
 
 export default publicWidget.registry.TermsAndConditionsCheckbox;


### PR DESCRIPTION
This widget is registered using the same TermsAndConditionsCheckbox name as the native website_sale widget, so it overrides the original implementation completely.

As a result, the change event of the terms and conditions checkbox in the checkout is no longer handled and the payment button is not enabled until the payment method is selected again.

This widget should use a different registry name so both implementations can coexist.

https://github.com/odoo/odoo/blob/06361cf46237623b8232252da2a3e7763cd28cbc/addons/website_sale/static/src/js/terms_and_conditions_checkbox.js#L6

@Tecnativa TT63742

@carlos-lopez-tecnativa @eduezerouali-tecnativa please review